### PR TITLE
feat: Convert Carbon Object To Pointer

### DIFF
--- a/boundary.go
+++ b/boundary.go
@@ -2,7 +2,7 @@ package carbon
 
 // StartOfCentury returns a Carbon instance for start of the century.
 // 本世纪开始时间
-func (c Carbon) StartOfCentury() Carbon {
+func (c *Carbon) StartOfCentury() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -11,7 +11,7 @@ func (c Carbon) StartOfCentury() Carbon {
 
 // EndOfCentury returns a Carbon instance for end of the century.
 // 本世纪结束时间
-func (c Carbon) EndOfCentury() Carbon {
+func (c *Carbon) EndOfCentury() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -20,7 +20,7 @@ func (c Carbon) EndOfCentury() Carbon {
 
 // StartOfDecade returns a Carbon instance for start of the decade.
 // 本年代开始时间
-func (c Carbon) StartOfDecade() Carbon {
+func (c *Carbon) StartOfDecade() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -29,7 +29,7 @@ func (c Carbon) StartOfDecade() Carbon {
 
 // EndOfDecade returns a Carbon instance for end of the decade.
 // 本年代结束时间
-func (c Carbon) EndOfDecade() Carbon {
+func (c *Carbon) EndOfDecade() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -38,7 +38,7 @@ func (c Carbon) EndOfDecade() Carbon {
 
 // StartOfYear returns a Carbon instance for start of the year.
 // 本年开始时间
-func (c Carbon) StartOfYear() Carbon {
+func (c *Carbon) StartOfYear() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -47,7 +47,7 @@ func (c Carbon) StartOfYear() Carbon {
 
 // EndOfYear returns a Carbon instance for end of the year.
 // 本年结束时间
-func (c Carbon) EndOfYear() Carbon {
+func (c *Carbon) EndOfYear() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -56,7 +56,7 @@ func (c Carbon) EndOfYear() Carbon {
 
 // StartOfQuarter returns a Carbon instance for start of the quarter.
 // 本季度开始时间
-func (c Carbon) StartOfQuarter() Carbon {
+func (c *Carbon) StartOfQuarter() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -66,7 +66,7 @@ func (c Carbon) StartOfQuarter() Carbon {
 
 // EndOfQuarter returns a Carbon instance for end of the quarter.
 // 本季度结束时间
-func (c Carbon) EndOfQuarter() Carbon {
+func (c *Carbon) EndOfQuarter() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -82,7 +82,7 @@ func (c Carbon) EndOfQuarter() Carbon {
 
 // StartOfMonth returns a Carbon instance for start of the month.
 // 本月开始时间
-func (c Carbon) StartOfMonth() Carbon {
+func (c *Carbon) StartOfMonth() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -92,7 +92,7 @@ func (c Carbon) StartOfMonth() Carbon {
 
 // EndOfMonth returns a Carbon instance for end of the month.
 // 本月结束时间
-func (c Carbon) EndOfMonth() Carbon {
+func (c *Carbon) EndOfMonth() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -102,7 +102,7 @@ func (c Carbon) EndOfMonth() Carbon {
 
 // StartOfWeek returns a Carbon instance for start of the week.
 // 本周开始时间
-func (c Carbon) StartOfWeek() Carbon {
+func (c *Carbon) StartOfWeek() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -112,7 +112,7 @@ func (c Carbon) StartOfWeek() Carbon {
 
 // EndOfWeek returns a Carbon instance for end of the week.
 // 本周结束时间
-func (c Carbon) EndOfWeek() Carbon {
+func (c *Carbon) EndOfWeek() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -122,7 +122,7 @@ func (c Carbon) EndOfWeek() Carbon {
 
 // StartOfDay returns a Carbon instance for start of the day.
 // 本日开始时间
-func (c Carbon) StartOfDay() Carbon {
+func (c *Carbon) StartOfDay() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -132,7 +132,7 @@ func (c Carbon) StartOfDay() Carbon {
 
 // EndOfDay returns a Carbon instance for end of the day.
 // 本日结束时间
-func (c Carbon) EndOfDay() Carbon {
+func (c *Carbon) EndOfDay() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -142,7 +142,7 @@ func (c Carbon) EndOfDay() Carbon {
 
 // StartOfHour returns a Carbon instance for start of the hour.
 // 小时开始时间
-func (c Carbon) StartOfHour() Carbon {
+func (c *Carbon) StartOfHour() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -152,7 +152,7 @@ func (c Carbon) StartOfHour() Carbon {
 
 // EndOfHour returns a Carbon instance for end of the hour.
 // 小时结束时间
-func (c Carbon) EndOfHour() Carbon {
+func (c *Carbon) EndOfHour() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -162,7 +162,7 @@ func (c Carbon) EndOfHour() Carbon {
 
 // StartOfMinute returns a Carbon instance for start of the minute.
 // 分钟开始时间
-func (c Carbon) StartOfMinute() Carbon {
+func (c *Carbon) StartOfMinute() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -172,7 +172,7 @@ func (c Carbon) StartOfMinute() Carbon {
 
 // EndOfMinute returns a Carbon instance for end of the minute.
 // 分钟结束时间
-func (c Carbon) EndOfMinute() Carbon {
+func (c *Carbon) EndOfMinute() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -182,7 +182,7 @@ func (c Carbon) EndOfMinute() Carbon {
 
 // StartOfSecond returns a Carbon instance for start of the second.
 // 秒开始时间
-func (c Carbon) StartOfSecond() Carbon {
+func (c *Carbon) StartOfSecond() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -192,7 +192,7 @@ func (c Carbon) StartOfSecond() Carbon {
 
 // EndOfSecond returns a Carbon instance for end of the second.
 // 秒结束时间
-func (c Carbon) EndOfSecond() Carbon {
+func (c *Carbon) EndOfSecond() *Carbon {
 	if c.Error != nil {
 		return c
 	}

--- a/boundary_unit_test.go
+++ b/boundary_unit_test.go
@@ -9,7 +9,7 @@ import (
 func TestCarbon_StartOfCentury(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -49,7 +49,7 @@ func TestCarbon_StartOfCentury(t *testing.T) {
 func TestCarbon_EndOfCentury(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -89,7 +89,7 @@ func TestCarbon_EndOfCentury(t *testing.T) {
 func TestCarbon_StartOfDecade(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -134,7 +134,7 @@ func TestCarbon_StartOfDecade(t *testing.T) {
 func TestCarbon_EndOfDecade(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -179,7 +179,7 @@ func TestCarbon_EndOfDecade(t *testing.T) {
 func TestCarbon_StartOfYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -219,7 +219,7 @@ func TestCarbon_StartOfYear(t *testing.T) {
 func TestCarbon_EndOfYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -259,7 +259,7 @@ func TestCarbon_EndOfYear(t *testing.T) {
 func TestCarbon_StartOfQuarter(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -299,7 +299,7 @@ func TestCarbon_StartOfQuarter(t *testing.T) {
 func TestCarbon_EndOfQuarter(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -349,7 +349,7 @@ func TestCarbon_EndOfQuarter(t *testing.T) {
 func TestCarbon_StartOfMonth(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -389,7 +389,7 @@ func TestCarbon_StartOfMonth(t *testing.T) {
 func TestCarbon_EndOfMonth(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -429,7 +429,7 @@ func TestCarbon_EndOfMonth(t *testing.T) {
 func TestCarbon_StartOfWeek(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -469,7 +469,7 @@ func TestCarbon_StartOfWeek(t *testing.T) {
 func TestCarbon_EndOfWeek(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -509,7 +509,7 @@ func TestCarbon_EndOfWeek(t *testing.T) {
 func TestCarbon_StartOfDay(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -549,7 +549,7 @@ func TestCarbon_StartOfDay(t *testing.T) {
 func TestCarbon_EndOfDay(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -589,7 +589,7 @@ func TestCarbon_EndOfDay(t *testing.T) {
 func TestCarbon_StartOfHour(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -629,7 +629,7 @@ func TestCarbon_StartOfHour(t *testing.T) {
 func TestCarbon_EndOfHour(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -679,7 +679,7 @@ func TestCarbon_EndOfHour(t *testing.T) {
 func TestCarbon_StartOfMinute(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -729,7 +729,7 @@ func TestCarbon_StartOfMinute(t *testing.T) {
 func TestCarbon_EndOfMinute(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -769,7 +769,7 @@ func TestCarbon_EndOfMinute(t *testing.T) {
 func TestCarbon_StartOfSecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -809,7 +809,7 @@ func TestCarbon_StartOfSecond(t *testing.T) {
 func TestCarbon_EndOfSecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{

--- a/calendar.go
+++ b/calendar.go
@@ -18,14 +18,14 @@ func (c Carbon) Lunar() (l lunar.Lunar) {
 
 // CreateFromLunar creates a Carbon instance from Lunar date and time.
 // 从 农历日期 创建 Carbon 实例
-func CreateFromLunar(year, month, day, hour, minute, second int, isLeapMonth bool) Carbon {
+func CreateFromLunar(year, month, day, hour, minute, second int, isLeapMonth bool) *Carbon {
 	t := lunar.FromLunar(year, month, day, hour, minute, second, isLeapMonth).ToGregorian().Time
 	return CreateFromStdTime(t)
 }
 
 // Julian converts Carbon instance to Julian instance.
 // 将 Carbon 实例转化为 Julian 实例
-func (c Carbon) Julian() (j julian.Julian) {
+func (c *Carbon) Julian() (j julian.Julian) {
 	if c.Error != nil {
 		return
 	}
@@ -34,14 +34,14 @@ func (c Carbon) Julian() (j julian.Julian) {
 
 // CreateFromJulian creates a Carbon instance from Julian Day or Modified Julian Day.
 // 从 儒略日/简化儒略日 创建 Carbon 实例
-func CreateFromJulian(f float64) Carbon {
+func CreateFromJulian(f float64) *Carbon {
 	t := julian.FromJulian(f).ToGregorian().Time
 	return CreateFromStdTime(t)
 }
 
 // Persian converts Carbon instance to Persian instance.
 // 将 Carbon 实例转化为 Persian 实例
-func (c Carbon) Persian() (p persian.Persian) {
+func (c *Carbon) Persian() (p persian.Persian) {
 	if c.Error != nil {
 		return
 	}
@@ -50,7 +50,7 @@ func (c Carbon) Persian() (p persian.Persian) {
 
 // CreateFromPersian creates a Carbon instance from Persian date and time.
 // 从 波斯日期 创建 Carbon 实例
-func CreateFromPersian(year, month, day, hour, minute, second int) (c Carbon) {
+func CreateFromPersian(year, month, day, hour, minute, second int) (c *Carbon) {
 	p := persian.FromPersian(year, month, day, hour, minute, second)
 	if p.Error != nil {
 		c.Error = p.Error

--- a/calendar_unit_test.go
+++ b/calendar_unit_test.go
@@ -9,7 +9,7 @@ import (
 func TestCarbon_Lunar(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -44,7 +44,7 @@ func TestCarbon_Lunar(t *testing.T) {
 func TestCreateFromLunar(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -79,7 +79,7 @@ func TestCreateFromLunar(t *testing.T) {
 func TestCarbon_Julian(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon  Carbon
+		carbon  *Carbon
 		wantJD  float64
 		wantMJD float64
 	}{
@@ -120,7 +120,7 @@ func TestCarbon_Julian(t *testing.T) {
 func TestCarbon_CreateFromJulian(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -145,7 +145,7 @@ func TestCarbon_CreateFromJulian(t *testing.T) {
 func TestCarbon_Persian(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -180,7 +180,7 @@ func TestCarbon_Persian(t *testing.T) {
 func TestCarbon_CreateFromPersian(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -216,7 +216,7 @@ func TestCarbon_CreateFromPersian(t *testing.T) {
 func TestCarbon_Issue246(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{

--- a/carbon.go
+++ b/carbon.go
@@ -280,8 +280,8 @@ type Carbon struct {
 
 // NewCarbon returns a new Carbon instance.
 // 初始化 Carbon 结构体
-func NewCarbon() Carbon {
-	c := Carbon{lang: NewLanguage()}
+func NewCarbon() *Carbon {
+	c := &Carbon{lang: NewLanguage()}
 	c.loc, c.Error = getLocationByTimezone(defaultTimezone)
 	if weekday, ok := weekdays[defaultWeekStartsAt]; ok {
 		c.weekStartsAt = weekday
@@ -293,191 +293,191 @@ func NewCarbon() Carbon {
 // DateTime defines a DateTime struct.
 // 定义 DateTime 结构体
 type DateTime struct {
-	Carbon
+	*Carbon
 }
 
 // NewDateTime returns a new DateTime instance.
 // 初始化 DateTime 结构体
-func NewDateTime(carbon Carbon) DateTime {
+func NewDateTime(carbon *Carbon) DateTime {
 	return DateTime{Carbon: carbon}
 }
 
 // DateTimeMilli defines a DateTimeMilli struct.
 // 定义 DateTimeMilli 结构体
 type DateTimeMilli struct {
-	Carbon
+	*Carbon
 }
 
 // NewDateTimeMilli returns a new DateTimeMilli instance.
 // 初始化 DateTimeMilli 结构体
-func NewDateTimeMilli(carbon Carbon) DateTimeMilli {
+func NewDateTimeMilli(carbon *Carbon) DateTimeMilli {
 	return DateTimeMilli{Carbon: carbon}
 }
 
 // DateTimeMicro defines a DateTimeMicro struct.
 // 定义 DateTimeMicro 结构体
 type DateTimeMicro struct {
-	Carbon
+	*Carbon
 }
 
 // NewDateTimeMicro returns a new DateTimeMicro instance.
 // 初始化 DateTimeMicro 结构体
-func NewDateTimeMicro(carbon Carbon) DateTimeMicro {
+func NewDateTimeMicro(carbon *Carbon) DateTimeMicro {
 	return DateTimeMicro{Carbon: carbon}
 }
 
 // DateTimeNano defines a DateTimeNano struct.
 // 定义 DateTimeNano 结构体
 type DateTimeNano struct {
-	Carbon
+	*Carbon
 }
 
 // NewDateTimeNano returns a new DateTimeNano instance.
 // 初始化 DateTimeNano 结构体
-func NewDateTimeNano(carbon Carbon) DateTimeNano {
+func NewDateTimeNano(carbon *Carbon) DateTimeNano {
 	return DateTimeNano{Carbon: carbon}
 }
 
 // Date defines a Date struct.
 // 定义 Date 结构体
 type Date struct {
-	Carbon
+	*Carbon
 }
 
 // NewDate returns a new Date instance.
 // 初始化 Date 结构体
-func NewDate(carbon Carbon) Date {
+func NewDate(carbon *Carbon) Date {
 	return Date{Carbon: carbon}
 }
 
 // DateMilli defines a DateMilli struct.
 // 定义 DateMilli 结构体
 type DateMilli struct {
-	Carbon
+	*Carbon
 }
 
 // NewDateMilli returns a new DateMilli instance.
 // 初始化 DateMilli 结构体
-func NewDateMilli(carbon Carbon) DateMilli {
+func NewDateMilli(carbon *Carbon) DateMilli {
 	return DateMilli{Carbon: carbon}
 }
 
 // DateMicro defines a DateMicro struct.
 // 定义 DateMicro 结构体
 type DateMicro struct {
-	Carbon
+	*Carbon
 }
 
 // NewDateMicro returns a new DateMicro instance.
 // 初始化 DateMicro 结构体
-func NewDateMicro(carbon Carbon) DateMicro {
+func NewDateMicro(carbon *Carbon) DateMicro {
 	return DateMicro{Carbon: carbon}
 }
 
 // DateNano defines a DateNano struct.
 // 定义 DateNano 结构体
 type DateNano struct {
-	Carbon
+	*Carbon
 }
 
 // NewDateNano returns a new DateNano instance.
 // 初始化 DateNano 结构体
-func NewDateNano(carbon Carbon) DateNano {
+func NewDateNano(carbon *Carbon) DateNano {
 	return DateNano{Carbon: carbon}
 }
 
 // Time defines a Time struct.
 // 定义 Time 结构体
 type Time struct {
-	Carbon
+	*Carbon
 }
 
 // NewTime returns a new Time instance.
 // 初始化 Time 结构体
-func NewTime(carbon Carbon) Time {
+func NewTime(carbon *Carbon) Time {
 	return Time{Carbon: carbon}
 }
 
 // TimeMilli defines a TimeMilli struct.
 // 定义 TimeMilli 结构体
 type TimeMilli struct {
-	Carbon
+	*Carbon
 }
 
 // NewTimeMilli returns a new TimeMilli instance.
 // 初始化 TimeMilli 结构体
-func NewTimeMilli(carbon Carbon) TimeMilli {
+func NewTimeMilli(carbon *Carbon) TimeMilli {
 	return TimeMilli{Carbon: carbon}
 }
 
 // TimeMicro defines a TimeMicro struct.
 // 定义 TimeMicro 结构体
 type TimeMicro struct {
-	Carbon
+	*Carbon
 }
 
 // NewTimeMicro returns a new TimeMicro instance.
 // 初始化 TimeMicro 结构体
-func NewTimeMicro(carbon Carbon) TimeMicro {
+func NewTimeMicro(carbon *Carbon) TimeMicro {
 	return TimeMicro{Carbon: carbon}
 }
 
 // TimeNano defines a TimeNano struct.
 // 定义 TimeNano 结构体
 type TimeNano struct {
-	Carbon
+	*Carbon
 }
 
 // NewTimeNano returns a new TimeNano instance.
 // 初始化 TimeNano 结构体
-func NewTimeNano(carbon Carbon) TimeNano {
+func NewTimeNano(carbon *Carbon) TimeNano {
 	return TimeNano{Carbon: carbon}
 }
 
 // Timestamp defines a Timestamp struct.
 // 定义 Timestamp 结构体
 type Timestamp struct {
-	Carbon
+	*Carbon
 }
 
 // NewTimestamp returns a new Timestamp instance.
 // 初始化 Timestamp 结构体
-func NewTimestamp(carbon Carbon) Timestamp {
+func NewTimestamp(carbon *Carbon) Timestamp {
 	return Timestamp{Carbon: carbon}
 }
 
 // TimestampMilli defines a TimestampMilli struct.
 // 定义 TimestampMilli 结构体
 type TimestampMilli struct {
-	Carbon
+	*Carbon
 }
 
 // NewTimestampMilli returns a new TimestampMilli instance.
 // 初始化 TimestampMilli 结构体
-func NewTimestampMilli(carbon Carbon) TimestampMilli {
+func NewTimestampMilli(carbon *Carbon) TimestampMilli {
 	return TimestampMilli{Carbon: carbon}
 }
 
 // TimestampMicro defines a TimestampMicro struct.
 // 定义 TimestampMicro 结构体
 type TimestampMicro struct {
-	Carbon
+	*Carbon
 }
 
 // NewTimestampMicro returns a new TimestampMicro instance.
 // 初始化 TimestampMicro 结构体
-func NewTimestampMicro(carbon Carbon) TimestampMicro {
+func NewTimestampMicro(carbon *Carbon) TimestampMicro {
 	return TimestampMicro{Carbon: carbon}
 }
 
 // TimestampNano defines a TimestampNano struct.
 // 定义 TimestampNano 结构体
 type TimestampNano struct {
-	Carbon
+	*Carbon
 }
 
 // NewTimestampNano returns a new TimestampNano instance.
 // 初始化 TimestampNano 结构体
-func NewTimestampNano(carbon Carbon) TimestampNano {
+func NewTimestampNano(carbon *Carbon) TimestampNano {
 	return TimestampNano{Carbon: carbon}
 }

--- a/comparer.go
+++ b/comparer.go
@@ -6,19 +6,19 @@ import (
 
 // IsDST reports whether is daylight saving time.
 // 是否是夏令时
-func (c Carbon) IsDST() bool {
+func (c *Carbon) IsDST() bool {
 	return c.time.IsDST()
 }
 
 // IsZero reports whether is zero time(0001-01-01 00:00:00 +0000 UTC).
 // 是否是零值时间(0001-01-01 00:00:00 +0000 UTC)
-func (c Carbon) IsZero() bool {
+func (c *Carbon) IsZero() bool {
 	return c.time.IsZero()
 }
 
 // IsValid reports whether is valid time.
 // 是否是有效时间
-func (c Carbon) IsValid() bool {
+func (c *Carbon) IsValid() bool {
 	if c.IsZero() {
 		return false
 	}
@@ -30,25 +30,25 @@ func (c Carbon) IsValid() bool {
 
 // IsInvalid reports whether is invalid time.
 // 是否是无效时间
-func (c Carbon) IsInvalid() bool {
+func (c *Carbon) IsInvalid() bool {
 	return !c.IsValid()
 }
 
 // IsAM reports whether is before noon.
 // 是否是上午
-func (c Carbon) IsAM() bool {
+func (c *Carbon) IsAM() bool {
 	return c.Format("a") == "am"
 }
 
 // IsPM reports whether is after noon.
 // 是否是下午
-func (c Carbon) IsPM() bool {
+func (c *Carbon) IsPM() bool {
 	return c.Format("a") == "pm"
 }
 
 // IsNow reports whether is now time.
 // 是否是当前时间
-func (c Carbon) IsNow() bool {
+func (c *Carbon) IsNow() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -57,7 +57,7 @@ func (c Carbon) IsNow() bool {
 
 // IsFuture reports whether is future time.
 // 是否是未来时间
-func (c Carbon) IsFuture() bool {
+func (c *Carbon) IsFuture() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -66,7 +66,7 @@ func (c Carbon) IsFuture() bool {
 
 // IsPast reports whether is past time.
 // 是否是过去时间
-func (c Carbon) IsPast() bool {
+func (c *Carbon) IsPast() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -75,7 +75,7 @@ func (c Carbon) IsPast() bool {
 
 // IsLeapYear reports whether is a leap year.
 // 是否是闰年
-func (c Carbon) IsLeapYear() bool {
+func (c *Carbon) IsLeapYear() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -88,7 +88,7 @@ func (c Carbon) IsLeapYear() bool {
 
 // IsLongYear reports whether is a long year, see https://en.wikipedia.org/wiki/ISO_8601#Week_dates.
 // 是否是长年
-func (c Carbon) IsLongYear() bool {
+func (c *Carbon) IsLongYear() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -98,7 +98,7 @@ func (c Carbon) IsLongYear() bool {
 
 // IsJanuary reports whether is January.
 // 是否是一月
-func (c Carbon) IsJanuary() bool {
+func (c *Carbon) IsJanuary() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -107,7 +107,7 @@ func (c Carbon) IsJanuary() bool {
 
 // IsFebruary reports whether is February.
 // 是否是二月
-func (c Carbon) IsFebruary() bool {
+func (c *Carbon) IsFebruary() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -116,7 +116,7 @@ func (c Carbon) IsFebruary() bool {
 
 // IsMarch reports whether is March.
 // 是否是三月
-func (c Carbon) IsMarch() bool {
+func (c *Carbon) IsMarch() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -125,7 +125,7 @@ func (c Carbon) IsMarch() bool {
 
 // IsApril reports whether is April.
 // 是否是四月
-func (c Carbon) IsApril() bool {
+func (c *Carbon) IsApril() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -134,7 +134,7 @@ func (c Carbon) IsApril() bool {
 
 // IsMay reports whether is May.
 // 是否是五月
-func (c Carbon) IsMay() bool {
+func (c *Carbon) IsMay() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -143,7 +143,7 @@ func (c Carbon) IsMay() bool {
 
 // IsJune reports whether is June.
 // 是否是六月
-func (c Carbon) IsJune() bool {
+func (c *Carbon) IsJune() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -152,7 +152,7 @@ func (c Carbon) IsJune() bool {
 
 // IsJuly reports whether is July.
 // 是否是七月
-func (c Carbon) IsJuly() bool {
+func (c *Carbon) IsJuly() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -161,7 +161,7 @@ func (c Carbon) IsJuly() bool {
 
 // IsAugust reports whether is August.
 // 是否是八月
-func (c Carbon) IsAugust() bool {
+func (c *Carbon) IsAugust() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -170,7 +170,7 @@ func (c Carbon) IsAugust() bool {
 
 // IsSeptember reports whether is September.
 // 是否是九月
-func (c Carbon) IsSeptember() bool {
+func (c *Carbon) IsSeptember() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -179,7 +179,7 @@ func (c Carbon) IsSeptember() bool {
 
 // IsOctober reports whether is October.
 // 是否是十月
-func (c Carbon) IsOctober() bool {
+func (c *Carbon) IsOctober() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -188,7 +188,7 @@ func (c Carbon) IsOctober() bool {
 
 // IsNovember reports whether is November.
 // 是否是十一月
-func (c Carbon) IsNovember() bool {
+func (c *Carbon) IsNovember() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -197,7 +197,7 @@ func (c Carbon) IsNovember() bool {
 
 // IsDecember reports whether is December.
 // 是否是十二月
-func (c Carbon) IsDecember() bool {
+func (c *Carbon) IsDecember() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -206,7 +206,7 @@ func (c Carbon) IsDecember() bool {
 
 // IsMonday reports whether is Monday.
 // 是否是周一
-func (c Carbon) IsMonday() bool {
+func (c *Carbon) IsMonday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -215,7 +215,7 @@ func (c Carbon) IsMonday() bool {
 
 // IsTuesday reports whether is Tuesday.
 // 是否是周二
-func (c Carbon) IsTuesday() bool {
+func (c *Carbon) IsTuesday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -224,7 +224,7 @@ func (c Carbon) IsTuesday() bool {
 
 // IsWednesday reports whether is Wednesday.
 // 是否是周三
-func (c Carbon) IsWednesday() bool {
+func (c *Carbon) IsWednesday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -233,7 +233,7 @@ func (c Carbon) IsWednesday() bool {
 
 // IsThursday reports whether is Thursday.
 // 是否是周四
-func (c Carbon) IsThursday() bool {
+func (c *Carbon) IsThursday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -242,7 +242,7 @@ func (c Carbon) IsThursday() bool {
 
 // IsFriday reports whether is Friday.
 // 是否是周五
-func (c Carbon) IsFriday() bool {
+func (c *Carbon) IsFriday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -251,7 +251,7 @@ func (c Carbon) IsFriday() bool {
 
 // IsSaturday reports whether is Saturday.
 // 是否是周六
-func (c Carbon) IsSaturday() bool {
+func (c *Carbon) IsSaturday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -260,7 +260,7 @@ func (c Carbon) IsSaturday() bool {
 
 // IsSunday reports whether is Sunday.
 // 是否是周日
-func (c Carbon) IsSunday() bool {
+func (c *Carbon) IsSunday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -269,7 +269,7 @@ func (c Carbon) IsSunday() bool {
 
 // IsWeekday reports whether is weekday.
 // 是否是工作日
-func (c Carbon) IsWeekday() bool {
+func (c *Carbon) IsWeekday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -278,7 +278,7 @@ func (c Carbon) IsWeekday() bool {
 
 // IsWeekend reports whether is weekend.
 // 是否是周末
-func (c Carbon) IsWeekend() bool {
+func (c *Carbon) IsWeekend() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -287,7 +287,7 @@ func (c Carbon) IsWeekend() bool {
 
 // IsYesterday reports whether is yesterday.
 // 是否是昨天
-func (c Carbon) IsYesterday() bool {
+func (c *Carbon) IsYesterday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -296,7 +296,7 @@ func (c Carbon) IsYesterday() bool {
 
 // IsToday reports whether is today.
 // 是否是今天
-func (c Carbon) IsToday() bool {
+func (c *Carbon) IsToday() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -305,7 +305,7 @@ func (c Carbon) IsToday() bool {
 
 // IsTomorrow reports whether is tomorrow.
 // 是否是明天
-func (c Carbon) IsTomorrow() bool {
+func (c *Carbon) IsTomorrow() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -314,7 +314,7 @@ func (c Carbon) IsTomorrow() bool {
 
 // IsSameCentury reports whether is same century.
 // 是否是同一世纪
-func (c Carbon) IsSameCentury(t Carbon) bool {
+func (c *Carbon) IsSameCentury(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -323,7 +323,7 @@ func (c Carbon) IsSameCentury(t Carbon) bool {
 
 // IsSameDecade reports whether is same decade.
 // 是否是同一年代
-func (c Carbon) IsSameDecade(t Carbon) bool {
+func (c *Carbon) IsSameDecade(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -332,7 +332,7 @@ func (c Carbon) IsSameDecade(t Carbon) bool {
 
 // IsSameYear reports whether is same year.
 // 是否是同一年
-func (c Carbon) IsSameYear(t Carbon) bool {
+func (c *Carbon) IsSameYear(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -341,7 +341,7 @@ func (c Carbon) IsSameYear(t Carbon) bool {
 
 // IsSameQuarter reports whether is same quarter.
 // 是否是同一季节
-func (c Carbon) IsSameQuarter(t Carbon) bool {
+func (c *Carbon) IsSameQuarter(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -350,7 +350,7 @@ func (c Carbon) IsSameQuarter(t Carbon) bool {
 
 // IsSameMonth reports whether is same month.
 // 是否是同一月
-func (c Carbon) IsSameMonth(t Carbon) bool {
+func (c *Carbon) IsSameMonth(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -359,7 +359,7 @@ func (c Carbon) IsSameMonth(t Carbon) bool {
 
 // IsSameDay reports whether is same day.
 // 是否是同一天
-func (c Carbon) IsSameDay(t Carbon) bool {
+func (c *Carbon) IsSameDay(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -368,7 +368,7 @@ func (c Carbon) IsSameDay(t Carbon) bool {
 
 // IsSameHour reports whether is same hour.
 // 是否是同一小时
-func (c Carbon) IsSameHour(t Carbon) bool {
+func (c *Carbon) IsSameHour(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -377,7 +377,7 @@ func (c Carbon) IsSameHour(t Carbon) bool {
 
 // IsSameMinute reports whether is same minute.
 // 是否是同一分钟
-func (c Carbon) IsSameMinute(t Carbon) bool {
+func (c *Carbon) IsSameMinute(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -386,17 +386,16 @@ func (c Carbon) IsSameMinute(t Carbon) bool {
 
 // IsSameSecond reports whether is same second.
 // 是否是同一秒
-func (c Carbon) IsSameSecond(t Carbon) bool {
+func (c *Carbon) IsSameSecond(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
 	return c.Format("YmdHis") == t.Format("YmdHis")
-
 }
 
 // Compare compares by an operator.
 // 时间比较
-func (c Carbon) Compare(operator string, t Carbon) bool {
+func (c *Carbon) Compare(operator string, t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -419,7 +418,7 @@ func (c Carbon) Compare(operator string, t Carbon) bool {
 
 // Gt reports whether greater than.
 // 是否大于
-func (c Carbon) Gt(t Carbon) bool {
+func (c *Carbon) Gt(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -428,7 +427,7 @@ func (c Carbon) Gt(t Carbon) bool {
 
 // Lt reports whether less than.
 // 是否小于
-func (c Carbon) Lt(t Carbon) bool {
+func (c *Carbon) Lt(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -437,7 +436,7 @@ func (c Carbon) Lt(t Carbon) bool {
 
 // Eq reports whether equal.
 // 是否等于
-func (c Carbon) Eq(t Carbon) bool {
+func (c *Carbon) Eq(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -446,13 +445,13 @@ func (c Carbon) Eq(t Carbon) bool {
 
 // Ne reports whether not equal.
 // 是否不等于
-func (c Carbon) Ne(t Carbon) bool {
+func (c *Carbon) Ne(t *Carbon) bool {
 	return !c.Eq(t)
 }
 
 // Gte reports whether greater than or equal.
 // 是否大于等于
-func (c Carbon) Gte(t Carbon) bool {
+func (c *Carbon) Gte(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -461,7 +460,7 @@ func (c Carbon) Gte(t Carbon) bool {
 
 // Lte reports whether less than or equal.
 // 是否小于等于
-func (c Carbon) Lte(t Carbon) bool {
+func (c *Carbon) Lte(t *Carbon) bool {
 	if c.Error != nil || t.Error != nil {
 		return false
 	}
@@ -470,7 +469,7 @@ func (c Carbon) Lte(t Carbon) bool {
 
 // Between reports whether between two times, excluded the start and end time.
 // 是否在两个时间之间(不包括这两个时间)
-func (c Carbon) Between(start Carbon, end Carbon) bool {
+func (c *Carbon) Between(start *Carbon, end *Carbon) bool {
 	if c.Error != nil || start.Error != nil || end.Error != nil {
 		return false
 	}
@@ -482,7 +481,7 @@ func (c Carbon) Between(start Carbon, end Carbon) bool {
 
 // BetweenIncludedStart reports whether between two times, included the start time.
 // 是否在两个时间之间(包括开始时间)
-func (c Carbon) BetweenIncludedStart(start Carbon, end Carbon) bool {
+func (c *Carbon) BetweenIncludedStart(start *Carbon, end *Carbon) bool {
 	if c.Error != nil || start.Error != nil || end.Error != nil {
 		return false
 	}
@@ -494,7 +493,7 @@ func (c Carbon) BetweenIncludedStart(start Carbon, end Carbon) bool {
 
 // BetweenIncludedEnd reports whether between two times, included the end time.
 // 是否在两个时间之间(包括结束时间)
-func (c Carbon) BetweenIncludedEnd(start Carbon, end Carbon) bool {
+func (c *Carbon) BetweenIncludedEnd(start *Carbon, end *Carbon) bool {
 	if c.Error != nil || start.Error != nil || end.Error != nil {
 		return false
 	}
@@ -506,7 +505,7 @@ func (c Carbon) BetweenIncludedEnd(start Carbon, end Carbon) bool {
 
 // BetweenIncludedBoth reports whether between two times, included the start and end time.
 // 是否在两个时间之间(包括这两个时间)
-func (c Carbon) BetweenIncludedBoth(start Carbon, end Carbon) bool {
+func (c *Carbon) BetweenIncludedBoth(start *Carbon, end *Carbon) bool {
 	if c.Error != nil || start.Error != nil || end.Error != nil {
 		return false
 	}

--- a/comparer_unit_test.go
+++ b/comparer_unit_test.go
@@ -1,8 +1,9 @@
 package carbon
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCarbon_IsDST(t *testing.T) {
@@ -10,7 +11,7 @@ func TestCarbon_IsDST(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -55,7 +56,7 @@ func TestCarbon_IsDST(t *testing.T) {
 func TestCarbon_IsZero(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -115,7 +116,7 @@ func TestCarbon_IsZero(t *testing.T) {
 func TestCarbon_IsValid(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -160,7 +161,7 @@ func TestCarbon_IsValid(t *testing.T) {
 func TestCarbon_IsInvalid(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -200,7 +201,7 @@ func TestCarbon_IsInvalid(t *testing.T) {
 func TestCarbon_IsAM(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -235,7 +236,7 @@ func TestCarbon_IsAM(t *testing.T) {
 func TestCarbon_IsPM(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -270,7 +271,7 @@ func TestCarbon_IsPM(t *testing.T) {
 func TestCarbon_IsNow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -305,7 +306,7 @@ func TestCarbon_IsNow(t *testing.T) {
 func TestCarbon_IsFuture(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -340,7 +341,7 @@ func TestCarbon_IsFuture(t *testing.T) {
 func TestCarbon_IsPast(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -375,7 +376,7 @@ func TestCarbon_IsPast(t *testing.T) {
 func TestCarbon_IsLeapYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -410,7 +411,7 @@ func TestCarbon_IsLeapYear(t *testing.T) {
 func TestCarbon_IsLongYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -445,7 +446,7 @@ func TestCarbon_IsLongYear(t *testing.T) {
 func TestCarbon_IsJanuary(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -475,7 +476,7 @@ func TestCarbon_IsJanuary(t *testing.T) {
 func TestCarbon_IsFebruary(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -505,7 +506,7 @@ func TestCarbon_IsFebruary(t *testing.T) {
 func TestCarbon_IsMarch(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -535,7 +536,7 @@ func TestCarbon_IsMarch(t *testing.T) {
 func TestCarbon_IsApril(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -565,7 +566,7 @@ func TestCarbon_IsApril(t *testing.T) {
 func TestCarbon_IsMay(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -595,7 +596,7 @@ func TestCarbon_IsMay(t *testing.T) {
 func TestCarbon_IsJune(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -625,7 +626,7 @@ func TestCarbon_IsJune(t *testing.T) {
 func TestCarbon_IsJuly(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -655,7 +656,7 @@ func TestCarbon_IsJuly(t *testing.T) {
 func TestCarbon_IsAugust(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -685,7 +686,7 @@ func TestCarbon_IsAugust(t *testing.T) {
 func TestCarbon_IsSeptember(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -715,7 +716,7 @@ func TestCarbon_IsSeptember(t *testing.T) {
 func TestCarbon_IsOctober(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -745,7 +746,7 @@ func TestCarbon_IsOctober(t *testing.T) {
 func TestCarbon_IsNovember(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -775,7 +776,7 @@ func TestCarbon_IsNovember(t *testing.T) {
 func TestCarbon_IsDecember(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -805,7 +806,7 @@ func TestCarbon_IsDecember(t *testing.T) {
 func TestCarbon_IsMonday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -835,7 +836,7 @@ func TestCarbon_IsMonday(t *testing.T) {
 func TestCarbon_IsTuesday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -865,7 +866,7 @@ func TestCarbon_IsTuesday(t *testing.T) {
 func TestCarbon_IsWednesday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -895,7 +896,7 @@ func TestCarbon_IsWednesday(t *testing.T) {
 func TestCarbon_IsThursday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -925,7 +926,7 @@ func TestCarbon_IsThursday(t *testing.T) {
 func TestCarbon_IsFriday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -955,7 +956,7 @@ func TestCarbon_IsFriday(t *testing.T) {
 func TestCarbon_IsSaturday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -985,7 +986,7 @@ func TestCarbon_IsSaturday(t *testing.T) {
 func TestCarbon_IsSunday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -1015,7 +1016,7 @@ func TestCarbon_IsSunday(t *testing.T) {
 func TestCarbon_IsWeekday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -1045,7 +1046,7 @@ func TestCarbon_IsWeekday(t *testing.T) {
 func TestCarbon_IsWeekend(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -1075,7 +1076,7 @@ func TestCarbon_IsWeekend(t *testing.T) {
 func TestCarbon_IsYesterday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -1115,7 +1116,7 @@ func TestCarbon_IsYesterday(t *testing.T) {
 func TestCarbon_IsToday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -1156,7 +1157,7 @@ func TestCarbon_IsTomorrow(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -1196,8 +1197,8 @@ func TestCarbon_IsTomorrow(t *testing.T) {
 func TestCarbon_IsSameCentury(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    bool
 	}{
 		{
@@ -1236,8 +1237,8 @@ func TestCarbon_IsSameCentury(t *testing.T) {
 func TestCarbon_IsSameDecade(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    bool
 	}{
 		{
@@ -1270,8 +1271,8 @@ func TestCarbon_IsSameDecade(t *testing.T) {
 func TestCarbon_IsSameYear(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    bool
 	}{
 		{
@@ -1304,8 +1305,8 @@ func TestCarbon_IsSameYear(t *testing.T) {
 func TestCarbon_IsSameQuarter(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    bool
 	}{
 		{
@@ -1338,8 +1339,8 @@ func TestCarbon_IsSameQuarter(t *testing.T) {
 func TestCarbon_IsSameMonth(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    bool
 	}{
 		{
@@ -1372,8 +1373,8 @@ func TestCarbon_IsSameMonth(t *testing.T) {
 func TestCarbon_IsSameDay(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    bool
 	}{
 		{
@@ -1406,8 +1407,8 @@ func TestCarbon_IsSameDay(t *testing.T) {
 func TestCarbon_IsSameHour(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    bool
 	}{
 		{
@@ -1440,8 +1441,8 @@ func TestCarbon_IsSameHour(t *testing.T) {
 func TestCarbon_IsSameMinute(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    bool
 	}{
 		{
@@ -1474,8 +1475,8 @@ func TestCarbon_IsSameMinute(t *testing.T) {
 func TestCarbon_IsSameSecond(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    bool
 	}{
 		{

--- a/constellation_unit_test.go
+++ b/constellation_unit_test.go
@@ -9,7 +9,7 @@ import (
 func TestCarbon_Constellation(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -99,7 +99,7 @@ func TestCarbon_Constellation(t *testing.T) {
 func TestCarbon_IsAries(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -134,7 +134,7 @@ func TestCarbon_IsAries(t *testing.T) {
 func TestCarbon_IsTaurus(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -169,7 +169,7 @@ func TestCarbon_IsTaurus(t *testing.T) {
 func TestCarbon_IsGemini(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -204,7 +204,7 @@ func TestCarbon_IsGemini(t *testing.T) {
 func TestCarbon_IsCancer(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -239,7 +239,7 @@ func TestCarbon_IsCancer(t *testing.T) {
 func TestCarbon_IsLeo(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -274,7 +274,7 @@ func TestCarbon_IsLeo(t *testing.T) {
 func TestCarbon_IsVirgo(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -309,7 +309,7 @@ func TestCarbon_IsVirgo(t *testing.T) {
 func TestCarbon_IsLibra(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -344,7 +344,7 @@ func TestCarbon_IsLibra(t *testing.T) {
 func TestCarbon_IsScorpio(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -379,7 +379,7 @@ func TestCarbon_IsScorpio(t *testing.T) {
 func TestCarbon_IsSagittarius(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -414,7 +414,7 @@ func TestCarbon_IsSagittarius(t *testing.T) {
 func TestCarbon_IsCapricorn(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -449,7 +449,7 @@ func TestCarbon_IsCapricorn(t *testing.T) {
 func TestCarbon_IsAquarius(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -484,7 +484,7 @@ func TestCarbon_IsAquarius(t *testing.T) {
 func TestCarbon_IsPisces(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{

--- a/creator.go
+++ b/creator.go
@@ -6,7 +6,7 @@ import (
 
 // CreateFromStdTime creates a Carbon instance from standard time.Time.
 // 从标准的 time.Time 创建 Carbon 实例
-func CreateFromStdTime(tt time.Time, timezone ...string) Carbon {
+func CreateFromStdTime(tt time.Time, timezone ...string) *Carbon {
 	c := NewCarbon()
 	c.loc = tt.Location()
 	if len(timezone) > 0 {
@@ -18,7 +18,7 @@ func CreateFromStdTime(tt time.Time, timezone ...string) Carbon {
 
 // CreateFromTimestamp creates a Carbon instance from a given timestamp with second.
 // 从给定的秒级时间戳创建 Carbon 实例
-func (c Carbon) CreateFromTimestamp(timestamp int64, timezone ...string) Carbon {
+func (c *Carbon) CreateFromTimestamp(timestamp int64, timezone ...string) *Carbon {
 	if len(timezone) > 0 {
 		c.loc, c.Error = getLocationByTimezone(timezone[0])
 	}
@@ -31,13 +31,13 @@ func (c Carbon) CreateFromTimestamp(timestamp int64, timezone ...string) Carbon 
 
 // CreateFromTimestamp creates a Carbon instance from a given timestamp with second.
 // 从给定的秒级时间戳创建 Carbon 实例
-func CreateFromTimestamp(timestamp int64, timezone ...string) Carbon {
+func CreateFromTimestamp(timestamp int64, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromTimestamp(timestamp, timezone...)
 }
 
 // CreateFromTimestampMilli creates a Carbon instance from a given timestamp with millisecond.
 // 从给定的毫秒级时间戳创建 Carbon 实例
-func (c Carbon) CreateFromTimestampMilli(timestamp int64, timezone ...string) Carbon {
+func (c *Carbon) CreateFromTimestampMilli(timestamp int64, timezone ...string) *Carbon {
 	if len(timezone) > 0 {
 		c.loc, c.Error = getLocationByTimezone(timezone[0])
 	}
@@ -50,13 +50,13 @@ func (c Carbon) CreateFromTimestampMilli(timestamp int64, timezone ...string) Ca
 
 // CreateFromTimestampMilli creates a Carbon instance from a given timestamp with millisecond.
 // 从给定的毫秒级时间戳创建 Carbon 实例
-func CreateFromTimestampMilli(timestamp int64, timezone ...string) Carbon {
+func CreateFromTimestampMilli(timestamp int64, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromTimestampMilli(timestamp, timezone...)
 }
 
 // CreateFromTimestampMicro creates a Carbon instance from a given timestamp with microsecond.
 // 从给定的微秒级时间戳创建 Carbon 实例
-func (c Carbon) CreateFromTimestampMicro(timestamp int64, timezone ...string) Carbon {
+func (c *Carbon) CreateFromTimestampMicro(timestamp int64, timezone ...string) *Carbon {
 	if len(timezone) > 0 {
 		c.loc, c.Error = getLocationByTimezone(timezone[0])
 	}
@@ -69,13 +69,13 @@ func (c Carbon) CreateFromTimestampMicro(timestamp int64, timezone ...string) Ca
 
 // CreateFromTimestampMicro creates a Carbon instance from a given timestamp with microsecond.
 // 从给定的微秒级时间戳创建 Carbon 实例
-func CreateFromTimestampMicro(timestamp int64, timezone ...string) Carbon {
+func CreateFromTimestampMicro(timestamp int64, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromTimestampMicro(timestamp, timezone...)
 }
 
 // CreateFromTimestampNano creates a Carbon instance from a given timestamp with nanosecond.
 // 从给定的纳秒级时间戳创建 Carbon 实例
-func (c Carbon) CreateFromTimestampNano(timestamp int64, timezone ...string) Carbon {
+func (c *Carbon) CreateFromTimestampNano(timestamp int64, timezone ...string) *Carbon {
 	if len(timezone) > 0 {
 		c.loc, c.Error = getLocationByTimezone(timezone[0])
 	}
@@ -88,161 +88,161 @@ func (c Carbon) CreateFromTimestampNano(timestamp int64, timezone ...string) Car
 
 // CreateFromTimestampNano creates a Carbon instance from a given timestamp with nanosecond.
 // 从给定的纳秒级时间戳创建 Carbon 实例
-func CreateFromTimestampNano(timestamp int64, timezone ...string) Carbon {
+func CreateFromTimestampNano(timestamp int64, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromTimestampNano(timestamp, timezone...)
 }
 
 // CreateFromDateTime creates a Carbon instance from a given date and time.
 // 从给定的年、月、日、时、分、秒创建 Carbon 实例
-func (c Carbon) CreateFromDateTime(year, month, day, hour, minute, second int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromDateTime(year, month, day, hour, minute, second int, timezone ...string) *Carbon {
 	return c.create(year, month, day, hour, minute, second, 0, timezone...)
 }
 
 // CreateFromDateTime creates a Carbon instance from a given date and time.
 // 从给定的年、月、日、时、分、秒创建 Carbon 实例
-func CreateFromDateTime(year, month, day, hour, minute, second int, timezone ...string) Carbon {
+func CreateFromDateTime(year, month, day, hour, minute, second int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromDateTime(year, month, day, hour, minute, second, timezone...)
 }
 
 // CreateFromDateTimeMilli creates a Carbon instance from a given date, time and millisecond.
 // 从给定的年、月、日、时、分、秒、毫秒创建 Carbon 实例
-func (c Carbon) CreateFromDateTimeMilli(year, month, day, hour, minute, second, millisecond int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromDateTimeMilli(year, month, day, hour, minute, second, millisecond int, timezone ...string) *Carbon {
 	return c.create(year, month, day, hour, minute, second, millisecond*1e6, timezone...)
 }
 
 // CreateFromDateTimeMilli creates a Carbon instance from a given date, time and millisecond.
 // 从给定的年、月、日、时、分、秒、毫秒创建 Carbon 实例
-func CreateFromDateTimeMilli(year, month, day, hour, minute, second, millisecond int, timezone ...string) Carbon {
+func CreateFromDateTimeMilli(year, month, day, hour, minute, second, millisecond int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromDateTimeMilli(year, month, day, hour, minute, second, millisecond, timezone...)
 }
 
 // CreateFromDateTimeMicro creates a Carbon instance from a given date, time and microsecond.
 // 从给定的年、月、日、时、分、秒、微秒创建 Carbon 实例
-func (c Carbon) CreateFromDateTimeMicro(year, month, day, hour, minute, second, microsecond int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromDateTimeMicro(year, month, day, hour, minute, second, microsecond int, timezone ...string) *Carbon {
 	return c.create(year, month, day, hour, minute, second, microsecond*1e3, timezone...)
 }
 
 // CreateFromDateTimeMicro creates a Carbon instance from a given date, time and microsecond.
 // 从给定的年、月、日、时、分、秒、微秒创建 Carbon 实例
-func CreateFromDateTimeMicro(year, month, day, hour, minute, second, microsecond int, timezone ...string) Carbon {
+func CreateFromDateTimeMicro(year, month, day, hour, minute, second, microsecond int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromDateTimeMicro(year, month, day, hour, minute, second, microsecond, timezone...)
 }
 
 // CreateFromDateTimeNano creates a Carbon instance from a given date, time and nanosecond.
 // 从给定的年、月、日、时、分、秒、纳秒创建 Carbon 实例
-func (c Carbon) CreateFromDateTimeNano(year, month, day, hour, minute, second, nanosecond int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromDateTimeNano(year, month, day, hour, minute, second, nanosecond int, timezone ...string) *Carbon {
 	return c.create(year, month, day, hour, minute, second, nanosecond, timezone...)
 }
 
 // CreateFromDateTimeNano creates a Carbon instance from a given date, time and nanosecond.
 // 从给定的年、月、日、时、分、秒、纳秒创建 Carbon 实例
-func CreateFromDateTimeNano(year, month, day, hour, minute, second, nanosecond int, timezone ...string) Carbon {
+func CreateFromDateTimeNano(year, month, day, hour, minute, second, nanosecond int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromDateTimeNano(year, month, day, hour, minute, second, nanosecond, timezone...)
 }
 
 // CreateFromDate creates a Carbon instance from a given date.
 // 从给定的年、月、日创建 Carbon 实例
-func (c Carbon) CreateFromDate(year, month, day int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromDate(year, month, day int, timezone ...string) *Carbon {
 	return c.create(year, month, day, 0, 0, 0, 0, timezone...)
 }
 
 // CreateFromDate creates a Carbon instance from a given date.
 // 从给定的年、月、日创建 Carbon 实例
-func CreateFromDate(year, month, day int, timezone ...string) Carbon {
+func CreateFromDate(year, month, day int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromDate(year, month, day, timezone...)
 }
 
 // CreateFromDateMilli creates a Carbon instance from a given date and millisecond.
 // 从给定的年、月、日、毫秒创建 Carbon 实例
-func (c Carbon) CreateFromDateMilli(year, month, day, millisecond int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromDateMilli(year, month, day, millisecond int, timezone ...string) *Carbon {
 	return c.create(year, month, day, 0, 0, 0, millisecond*1e6, timezone...)
 }
 
 // CreateFromDateMilli creates a Carbon instance from a given date and millisecond.
 // 从给定的年、月、日、毫秒创建 Carbon 实例
-func CreateFromDateMilli(year, month, day, millisecond int, timezone ...string) Carbon {
+func CreateFromDateMilli(year, month, day, millisecond int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromDateMilli(year, month, day, millisecond, timezone...)
 }
 
 // CreateFromDateMicro creates a Carbon instance from a given date and microsecond.
 // 从给定的年、月、日、微秒创建 Carbon 实例
-func (c Carbon) CreateFromDateMicro(year, month, day, microsecond int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromDateMicro(year, month, day, microsecond int, timezone ...string) *Carbon {
 	return c.create(year, month, day, 0, 0, 0, microsecond*1e3, timezone...)
 }
 
 // CreateFromDateMicro creates a Carbon instance from a given date and microsecond.
 // 从给定的年、月、日、微秒创建 Carbon 实例
-func CreateFromDateMicro(year, month, day, microsecond int, timezone ...string) Carbon {
+func CreateFromDateMicro(year, month, day, microsecond int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromDateMicro(year, month, day, microsecond, timezone...)
 }
 
 // CreateFromDateNano creates a Carbon instance from a given date and nanosecond.
 // 从给定的年、月、日、纳秒创建 Carbon 实例
-func (c Carbon) CreateFromDateNano(year, month, day, nanosecond int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromDateNano(year, month, day, nanosecond int, timezone ...string) *Carbon {
 	return c.create(year, month, day, 0, 0, 0, nanosecond, timezone...)
 }
 
 // CreateFromDateNano creates a Carbon instance from a given date and nanosecond.
 // 从给定的年、月、日、纳秒创建 Carbon 实例
-func CreateFromDateNano(year, month, day, nanosecond int, timezone ...string) Carbon {
+func CreateFromDateNano(year, month, day, nanosecond int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromDateNano(year, month, day, nanosecond, timezone...)
 }
 
 // CreateFromTime creates a Carbon instance from a given time(year, month and day are taken from the current time).
 // 从给定的时、分、秒创建 Carbon 实例(年、月、日取自当前时间)
-func (c Carbon) CreateFromTime(hour, minute, second int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromTime(hour, minute, second int, timezone ...string) *Carbon {
 	year, month, day := c.Now(timezone...).Date()
 	return c.create(year, month, day, hour, minute, second, 0, timezone...)
 }
 
 // CreateFromTime creates a Carbon instance from a given time(year, month and day are taken from the current time).
 // 从给定的时、分、秒创建 Carbon 实例(年、月、日取自当前时间)
-func CreateFromTime(hour, minute, second int, timezone ...string) Carbon {
+func CreateFromTime(hour, minute, second int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromTime(hour, minute, second, timezone...)
 }
 
 // CreateFromTimeMilli creates a Carbon instance from a given time and millisecond(year, month and day are taken from the current time).
 // 从给定的时、分、秒、毫秒创建 Carbon 实例(年、月、日取自当前时间)
-func (c Carbon) CreateFromTimeMilli(hour, minute, second, millisecond int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromTimeMilli(hour, minute, second, millisecond int, timezone ...string) *Carbon {
 	year, month, day := c.Now(timezone...).Date()
 	return c.create(year, month, day, hour, minute, second, millisecond*1e6, timezone...)
 }
 
 // CreateFromTimeMilli creates a Carbon instance from a given time and millisecond(year, month and day are taken from the current time).
 // 从给定的时、分、秒、毫秒创建 Carbon 实例(年、月、日取自当前时间)
-func CreateFromTimeMilli(hour, minute, second, millisecond int, timezone ...string) Carbon {
+func CreateFromTimeMilli(hour, minute, second, millisecond int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromTimeMilli(hour, minute, second, millisecond, timezone...)
 }
 
 // CreateFromTimeMicro creates a Carbon instance from a given time and microsecond(year, month and day are taken from the current time).
 // 从给定的时、分、秒、微秒创建 Carbon 实例(年、月、日取自当前时间)
-func (c Carbon) CreateFromTimeMicro(hour, minute, second, microsecond int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromTimeMicro(hour, minute, second, microsecond int, timezone ...string) *Carbon {
 	year, month, day := c.Now(timezone...).Date()
 	return c.create(year, month, day, hour, minute, second, microsecond*1e3, timezone...)
 }
 
 // CreateFromTimeMicro creates a Carbon instance from a given time and microsecond(year, month and day are taken from the current time).
 // 从给定的时、分、秒、微秒创建 Carbon 实例(年、月、日取自当前时间)
-func CreateFromTimeMicro(hour, minute, second, microsecond int, timezone ...string) Carbon {
+func CreateFromTimeMicro(hour, minute, second, microsecond int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromTimeMicro(hour, minute, second, microsecond, timezone...)
 }
 
 // CreateFromTimeNano creates a Carbon instance from a given time and nanosecond(year, month and day are taken from the current time).
 // 从给定的时、分、秒、纳秒创建 Carbon 实例(年、月、日取自当前时间)
-func (c Carbon) CreateFromTimeNano(hour, minute, second, nanosecond int, timezone ...string) Carbon {
+func (c *Carbon) CreateFromTimeNano(hour, minute, second, nanosecond int, timezone ...string) *Carbon {
 	year, month, day := c.Now(timezone...).Date()
 	return c.create(year, month, day, hour, minute, second, nanosecond, timezone...)
 }
 
 // CreateFromTimeNano creates a Carbon instance from a given time and nanosecond(year, month and day are taken from the current time).
 // 从给定的时、分、秒、纳秒创建 Carbon 实例(年、月、日取自当前时间)
-func CreateFromTimeNano(hour, minute, second, nanosecond int, timezone ...string) Carbon {
+func CreateFromTimeNano(hour, minute, second, nanosecond int, timezone ...string) *Carbon {
 	return NewCarbon().CreateFromTimeNano(hour, minute, second, nanosecond, timezone...)
 }
 
 // creates a Carbon instance from a given date, time and nanosecond.
 // 从给定的年、月、日、时、分、秒、纳秒创建 Carbon 实例
-func (c Carbon) create(year, month, day, hour, minute, second, nanosecond int, timezone ...string) Carbon {
+func (c *Carbon) create(year, month, day, hour, minute, second, nanosecond int, timezone ...string) *Carbon {
 	if len(timezone) > 0 {
 		c.loc, c.Error = getLocationByTimezone(timezone[0])
 	}

--- a/creator_unit_test.go
+++ b/creator_unit_test.go
@@ -10,7 +10,7 @@ import (
 func TestCarbon_CreateFromStdTime(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -35,7 +35,7 @@ func TestCarbon_CreateFromStdTime(t *testing.T) {
 func TestCarbon_CreateFromTimestamp(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -75,7 +75,7 @@ func TestCarbon_CreateFromTimestamp(t *testing.T) {
 func TestCarbon_CreateFromTimestampMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -115,7 +115,7 @@ func TestCarbon_CreateFromTimestampMilli(t *testing.T) {
 func TestCarbon_CreateFromTimestampMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -155,7 +155,7 @@ func TestCarbon_CreateFromTimestampMicro(t *testing.T) {
 func TestCarbon_CreateFromTimestampNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -190,7 +190,7 @@ func TestCarbon_CreateFromTimestampNano(t *testing.T) {
 func TestCarbon_CreateFromDateTime(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -225,7 +225,7 @@ func TestCarbon_CreateFromDateTime(t *testing.T) {
 func TestCarbon_CreateFromDateTimeMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -260,7 +260,7 @@ func TestCarbon_CreateFromDateTimeMilli(t *testing.T) {
 func TestCarbon_CreateFromDateTimeMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -295,7 +295,7 @@ func TestCarbon_CreateFromDateTimeMicro(t *testing.T) {
 func TestCarbon_CreateFromDateTimeNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -330,7 +330,7 @@ func TestCarbon_CreateFromDateTimeNano(t *testing.T) {
 func TestCarbon_CreateFromDate(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -365,7 +365,7 @@ func TestCarbon_CreateFromDate(t *testing.T) {
 func TestCarbon_CreateFromDateMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -400,7 +400,7 @@ func TestCarbon_CreateFromDateMilli(t *testing.T) {
 func TestCarbon_CreateFromDateMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -435,7 +435,7 @@ func TestCarbon_CreateFromDateMicro(t *testing.T) {
 func TestCarbon_CreateFromDateNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -470,8 +470,8 @@ func TestCarbon_CreateFromDateNano(t *testing.T) {
 func TestCarbon_CreateFromTime(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
-		want   Carbon
+		carbon *Carbon
+		want   *Carbon
 	}{
 		{
 			name:   "case1",
@@ -505,8 +505,8 @@ func TestCarbon_CreateFromTime(t *testing.T) {
 func TestCarbon_CreateFromTimeMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
-		want   Carbon
+		carbon *Carbon
+		want   *Carbon
 	}{
 		{
 			name:   "case1",
@@ -540,8 +540,8 @@ func TestCarbon_CreateFromTimeMilli(t *testing.T) {
 func TestCarbon_CreateFromTimeMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
-		want   Carbon
+		carbon *Carbon
+		want   *Carbon
 	}{
 		{
 			name:   "case1",
@@ -575,8 +575,8 @@ func TestCarbon_CreateFromTimeMicro(t *testing.T) {
 func TestCarbon_CreateFromTimeNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
-		want   Carbon
+		carbon *Carbon
+		want   *Carbon
 	}{
 		{
 			name:   "case1",

--- a/database.go
+++ b/database.go
@@ -18,11 +18,11 @@ var failedScanError = func(src interface{}) error {
 func (c *Carbon) Scan(src interface{}) error {
 	switch v := src.(type) {
 	case []byte:
-		*c = Parse(string(v))
+		c = Parse(string(v))
 	case string:
-		*c = Parse(v)
+		c = Parse(v)
 	case time.Time:
-		*c = CreateFromStdTime(v)
+		c = CreateFromStdTime(v)
 	}
 	if c.Error == nil {
 		return nil
@@ -31,7 +31,7 @@ func (c *Carbon) Scan(src interface{}) error {
 }
 
 // Value the interface providing the Value method for package database/sql/driver.
-func (c Carbon) Value() (driver.Value, error) {
+func (c *Carbon) Value() (driver.Value, error) {
 	if c.IsZero() {
 		return nil, nil
 	}
@@ -40,7 +40,7 @@ func (c Carbon) Value() (driver.Value, error) {
 
 // MarshalJSON implements the interface json.Marshal for Carbon struct.
 // 实现 json.Marshaler 接口
-func (c Carbon) MarshalJSON() ([]byte, error) {
+func (c *Carbon) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"%s"`, c.Layout(c.layout))), nil
 }
 
@@ -51,7 +51,7 @@ func (c *Carbon) UnmarshalJSON(b []byte) error {
 	if value == "" || value == "null" {
 		return nil
 	}
-	*c = ParseByLayout(value, c.layout)
+	c = ParseByLayout(value, c.layout)
 	return c.Error
 }
 

--- a/database_unit_test.go
+++ b/database_unit_test.go
@@ -514,7 +514,7 @@ type Person struct {
 	Name string `json:"name"`
 	Age  int    `json:"age"`
 
-	Birthday1 Carbon `json:"birthday1"`
+	Birthday1 *Carbon `json:"birthday1"`
 
 	Birthday2 DateTime      `json:"birthday2"`
 	Birthday3 DateTimeMilli `json:"birthday3"`

--- a/difference.go
+++ b/difference.go
@@ -13,7 +13,7 @@ const (
 
 // DiffInYears gets the difference in years.
 // 相差多少年
-func (c Carbon) DiffInYears(carbon ...Carbon) int64 {
+func (c *Carbon) DiffInYears(carbon ...*Carbon) int64 {
 	start, end := c, c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -33,13 +33,13 @@ func (c Carbon) DiffInYears(carbon ...Carbon) int64 {
 
 // DiffAbsInYears gets the difference in years with absolute value.
 // 相差多少年(绝对值)
-func (c Carbon) DiffAbsInYears(carbon ...Carbon) int64 {
+func (c *Carbon) DiffAbsInYears(carbon ...*Carbon) int64 {
 	return getAbsValue(c.DiffInYears(carbon...))
 }
 
 // DiffInMonths gets the difference in months.
 // 相差多少月
-func (c Carbon) DiffInMonths(carbon ...Carbon) int64 {
+func (c *Carbon) DiffInMonths(carbon ...*Carbon) int64 {
 	start, end := c, c.Now()
 	if start.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -62,13 +62,13 @@ func (c Carbon) DiffInMonths(carbon ...Carbon) int64 {
 
 // DiffAbsInMonths gets the difference in months with absolute value.
 // 相差多少月(绝对值)
-func (c Carbon) DiffAbsInMonths(carbon ...Carbon) int64 {
+func (c *Carbon) DiffAbsInMonths(carbon ...*Carbon) int64 {
 	return getAbsValue(c.DiffInMonths(carbon...))
 }
 
 // DiffInWeeks gets the difference in weeks.
 // 相差多少周
-func (c Carbon) DiffInWeeks(carbon ...Carbon) int64 {
+func (c *Carbon) DiffInWeeks(carbon ...*Carbon) int64 {
 	start, end := c, c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -81,13 +81,13 @@ func (c Carbon) DiffInWeeks(carbon ...Carbon) int64 {
 
 // DiffAbsInWeeks gets the difference in weeks with absolute value.
 // 相差多少周(绝对值)
-func (c Carbon) DiffAbsInWeeks(carbon ...Carbon) int64 {
+func (c *Carbon) DiffAbsInWeeks(carbon ...*Carbon) int64 {
 	return getAbsValue(c.DiffInWeeks(carbon...))
 }
 
 // DiffInDays gets the difference in days.
 // 相差多少天
-func (c Carbon) DiffInDays(carbon ...Carbon) int64 {
+func (c *Carbon) DiffInDays(carbon ...*Carbon) int64 {
 	start, end := c, c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -100,13 +100,13 @@ func (c Carbon) DiffInDays(carbon ...Carbon) int64 {
 
 // DiffAbsInDays gets the difference in days with absolute value.
 // 相差多少天(绝对值)
-func (c Carbon) DiffAbsInDays(carbon ...Carbon) int64 {
+func (c *Carbon) DiffAbsInDays(carbon ...*Carbon) int64 {
 	return getAbsValue(c.DiffInDays(carbon...))
 }
 
 // DiffInHours gets the difference in hours.
 // 相差多少小时
-func (c Carbon) DiffInHours(carbon ...Carbon) int64 {
+func (c *Carbon) DiffInHours(carbon ...*Carbon) int64 {
 	end := c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -119,13 +119,13 @@ func (c Carbon) DiffInHours(carbon ...Carbon) int64 {
 
 // DiffAbsInHours gets the difference in hours with absolute value.
 // 相差多少小时(绝对值)
-func (c Carbon) DiffAbsInHours(carbon ...Carbon) int64 {
+func (c *Carbon) DiffAbsInHours(carbon ...*Carbon) int64 {
 	return getAbsValue(c.DiffInHours(carbon...))
 }
 
 // DiffInMinutes gets the difference in minutes.
 // 相差多少分钟
-func (c Carbon) DiffInMinutes(carbon ...Carbon) int64 {
+func (c *Carbon) DiffInMinutes(carbon ...*Carbon) int64 {
 	end := c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -138,13 +138,13 @@ func (c Carbon) DiffInMinutes(carbon ...Carbon) int64 {
 
 // DiffAbsInMinutes gets the difference in minutes with absolute value.
 // 相差多少分钟(绝对值)
-func (c Carbon) DiffAbsInMinutes(carbon ...Carbon) int64 {
+func (c *Carbon) DiffAbsInMinutes(carbon ...*Carbon) int64 {
 	return getAbsValue(c.DiffInMinutes(carbon...))
 }
 
 // DiffInSeconds gets the difference in seconds.
 // 相差多少秒
-func (c Carbon) DiffInSeconds(carbon ...Carbon) int64 {
+func (c *Carbon) DiffInSeconds(carbon ...*Carbon) int64 {
 	end := c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -157,13 +157,13 @@ func (c Carbon) DiffInSeconds(carbon ...Carbon) int64 {
 
 // DiffAbsInSeconds gets the difference in seconds with absolute value.
 // 相差多少秒(绝对值)
-func (c Carbon) DiffAbsInSeconds(carbon ...Carbon) int64 {
+func (c *Carbon) DiffAbsInSeconds(carbon ...*Carbon) int64 {
 	return getAbsValue(c.DiffInSeconds(carbon...))
 }
 
 // DiffInString gets the difference in string, i18n is supported.
 // 相差字符串，支持i18n
-func (c Carbon) DiffInString(carbon ...Carbon) string {
+func (c *Carbon) DiffInString(carbon ...*Carbon) string {
 	end := c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -180,7 +180,7 @@ func (c Carbon) DiffInString(carbon ...Carbon) string {
 
 // DiffAbsInString gets the difference in string with absolute value, i18n is supported.
 // 相差字符串，支持i18n(绝对值)
-func (c Carbon) DiffAbsInString(carbon ...Carbon) string {
+func (c *Carbon) DiffAbsInString(carbon ...*Carbon) string {
 	end := c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -197,7 +197,7 @@ func (c Carbon) DiffAbsInString(carbon ...Carbon) string {
 
 // DiffInDuration gets the difference in duration.
 // 相差时长
-func (c Carbon) DiffInDuration(carbon ...Carbon) time.Duration {
+func (c *Carbon) DiffInDuration(carbon ...*Carbon) time.Duration {
 	end := c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -210,7 +210,7 @@ func (c Carbon) DiffInDuration(carbon ...Carbon) time.Duration {
 
 // DiffAbsInDuration gets the difference in duration with absolute value.
 // 相差时长(绝对值)
-func (c Carbon) DiffAbsInDuration(carbon ...Carbon) time.Duration {
+func (c *Carbon) DiffAbsInDuration(carbon ...*Carbon) time.Duration {
 	d := c.DiffInDuration(carbon...)
 	if d >= 0 {
 		return d
@@ -220,7 +220,7 @@ func (c Carbon) DiffAbsInDuration(carbon ...Carbon) time.Duration {
 
 // DiffForHumans gets the difference in a human-readable format, i18n is supported.
 // 获取对人类友好的可读格式时间差，支持i18n
-func (c Carbon) DiffForHumans(carbon ...Carbon) string {
+func (c *Carbon) DiffForHumans(carbon ...*Carbon) string {
 	end := c.Now()
 	if c.IsSetTestNow() {
 		end = CreateFromTimestampNano(c.testNow, c.Location())
@@ -250,7 +250,7 @@ func (c Carbon) DiffForHumans(carbon ...Carbon) string {
 
 // gets the difference for unit and value.
 // 获取相差单位和差值
-func (c Carbon) diff(end Carbon) (unit string, value int64) {
+func (c *Carbon) diff(end *Carbon) (unit string, value int64) {
 	switch true {
 	case c.DiffAbsInYears(end) > 0:
 		unit = "year"
@@ -280,7 +280,7 @@ func (c Carbon) diff(end Carbon) (unit string, value int64) {
 	return
 }
 
-func getDiffInMonths(start, end Carbon) int64 {
+func getDiffInMonths(start, end *Carbon) int64 {
 	y, m, d, h, i, s, ns := start.DateTimeNano()
 	endYear, endMonth, _ := end.Date()
 

--- a/difference_unit_test.go
+++ b/difference_unit_test.go
@@ -9,8 +9,8 @@ import (
 func TestCarbon_DiffInYears(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -55,8 +55,8 @@ func TestCarbon_DiffInYears(t *testing.T) {
 func TestCarbon_DiffAbsInYears(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -101,8 +101,8 @@ func TestCarbon_DiffAbsInYears(t *testing.T) {
 func TestCarbon_DiffInMonths(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -141,8 +141,8 @@ func TestCarbon_DiffInMonths(t *testing.T) {
 func TestCarbon_DiffAbsInMonths(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -181,8 +181,8 @@ func TestCarbon_DiffAbsInMonths(t *testing.T) {
 func TestCarbon_DiffInWeeks(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -221,8 +221,8 @@ func TestCarbon_DiffInWeeks(t *testing.T) {
 func TestCarbon_DiffAbsInWeeks(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -261,8 +261,8 @@ func TestCarbon_DiffAbsInWeeks(t *testing.T) {
 func TestCarbon_DiffInDays(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -307,8 +307,8 @@ func TestCarbon_DiffInDays(t *testing.T) {
 func TestCarbon_DiffAbsInDays(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -353,8 +353,8 @@ func TestCarbon_DiffAbsInDays(t *testing.T) {
 func TestCarbon_DiffInHours(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -393,8 +393,8 @@ func TestCarbon_DiffInHours(t *testing.T) {
 func TestCarbon_DiffAbsInHours(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -433,8 +433,8 @@ func TestCarbon_DiffAbsInHours(t *testing.T) {
 func TestCarbon_DiffInMinutes(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -467,8 +467,8 @@ func TestCarbon_DiffInMinutes(t *testing.T) {
 func TestCarbon_DiffAbsInMinutes(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -501,8 +501,8 @@ func TestCarbon_DiffAbsInMinutes(t *testing.T) {
 func TestCarbon_DiffInSeconds(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -541,8 +541,8 @@ func TestCarbon_DiffInSeconds(t *testing.T) {
 func TestCarbon_DiffAbsInSeconds(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    int64
 	}{
 		{
@@ -582,8 +582,8 @@ func TestCarbon_DiffInString(t *testing.T) {
 	now := Now()
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    string
 	}{
 		{
@@ -708,8 +708,8 @@ func TestCarbon_DiffAbsInString(t *testing.T) {
 	now := Now()
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    string
 	}{
 		{
@@ -834,8 +834,8 @@ func TestCarbon_DiffInDuration(t *testing.T) {
 	now := Parse("2020-08-05 13:14:15")
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    string
 	}{
 		{
@@ -906,8 +906,8 @@ func TestCarbon_DiffAbsInDuration(t *testing.T) {
 	now := Parse("2020-08-05 13:14:15")
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    string
 	}{
 		{
@@ -977,8 +977,8 @@ func TestCarbon_DiffForHumans(t *testing.T) {
 	now := Now()
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
 		want    string
 	}{
 		{
@@ -1051,8 +1051,8 @@ func TestCarbon_DiffForHumans(t *testing.T) {
 func TestCarbon_Issue255(t *testing.T) {
 	tests := []struct {
 		name  string
-		start Carbon
-		end   Carbon
+		start *Carbon
+		end   *Carbon
 		want  int64
 	}{
 		{

--- a/extremum.go
+++ b/extremum.go
@@ -2,19 +2,19 @@ package carbon
 
 // MaxValue returns a Carbon instance for the greatest supported date.
 // 返回 Carbon 的最大值
-func MaxValue() Carbon {
+func MaxValue() *Carbon {
 	return NewCarbon().create(9999, 12, 31, 23, 59, 59, 999999999, UTC)
 }
 
 // MinValue returns a Carbon instance for the lowest supported date.
 // 返回 Carbon 的最小值
-func MinValue() Carbon {
+func MinValue() *Carbon {
 	return NewCarbon().create(-9998, 1, 1, 0, 0, 0, 0, UTC)
 }
 
 // Closest returns the closest Carbon instance from the given Carbon instance.
 // 返回离给定 carbon 实例最近的 Carbon 实例
-func (c Carbon) Closest(c1 Carbon, c2 Carbon) Carbon {
+func (c *Carbon) Closest(c1 *Carbon, c2 *Carbon) *Carbon {
 	if c1.Error != nil {
 		return c2
 	}
@@ -29,7 +29,7 @@ func (c Carbon) Closest(c1 Carbon, c2 Carbon) Carbon {
 
 // Farthest returns the farthest Carbon instance from the given Carbon instance.
 // 返回离给定 carbon 实例最远的 Carbon 实例
-func (c Carbon) Farthest(c1 Carbon, c2 Carbon) Carbon {
+func (c *Carbon) Farthest(c1 *Carbon, c2 *Carbon) *Carbon {
 	if c1.IsZero() || c1.IsInvalid() {
 		return c2
 	}
@@ -44,24 +44,24 @@ func (c Carbon) Farthest(c1 Carbon, c2 Carbon) Carbon {
 
 // Max returns the maximum Carbon instance from the given Carbon instance (second-precision).
 // 返回最大的 Carbon 实例
-func Max(c1 Carbon, c2 ...Carbon) (c Carbon) {
-	c = c1
+func Max(c1 *Carbon, c2 ...*Carbon) *Carbon {
+	c := c1
 	for i := range c2 {
 		if c2[i].Gte(c) {
 			c = c2[i]
 		}
 	}
-	return
+	return c
 }
 
 // Min returns the minimum Carbon instance from the given Carbon instance (second-precision).
 // 返回最小的 Carbon 实例
-func Min(c1 Carbon, c2 ...Carbon) (c Carbon) {
-	c = c1
+func Min(c1 *Carbon, c2 ...*Carbon) *Carbon {
+	c := c1
 	for i := range c2 {
 		if c2[i].Lte(c) {
 			c = c2[i]
 		}
 	}
-	return
+	return c
 }

--- a/extremum_unit_test.go
+++ b/extremum_unit_test.go
@@ -1,16 +1,17 @@
 package carbon
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCarbon_Closest(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
-		carbon3 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
+		carbon3 *Carbon
 		want    string
 	}{
 		{
@@ -66,9 +67,9 @@ func TestCarbon_Closest(t *testing.T) {
 func TestCarbon_Farthest(t *testing.T) {
 	tests := []struct {
 		name    string
-		carbon1 Carbon
-		carbon2 Carbon
-		carbon3 Carbon
+		carbon1 *Carbon
+		carbon2 *Carbon
+		carbon3 *Carbon
 		want    string
 	}{
 		{

--- a/getter.go
+++ b/getter.go
@@ -6,7 +6,7 @@ import (
 
 // StdTime gets standard time.Time.
 // 获取标准 time.Time
-func (c Carbon) StdTime() time.Time {
+func (c *Carbon) StdTime() time.Time {
 	if c.time.IsZero() {
 		return c.time
 	}
@@ -15,7 +15,7 @@ func (c Carbon) StdTime() time.Time {
 
 // DaysInYear gets total days in year like 365.
 // 获取本年的总天数
-func (c Carbon) DaysInYear() int {
+func (c *Carbon) DaysInYear() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -27,7 +27,7 @@ func (c Carbon) DaysInYear() int {
 
 // DaysInMonth gets total days in month like 30.
 // 获取本月的总天数
-func (c Carbon) DaysInMonth() int {
+func (c *Carbon) DaysInMonth() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -36,7 +36,7 @@ func (c Carbon) DaysInMonth() int {
 
 // MonthOfYear gets month of year like 12.
 // 获取本年的第几月
-func (c Carbon) MonthOfYear() int {
+func (c *Carbon) MonthOfYear() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -45,7 +45,7 @@ func (c Carbon) MonthOfYear() int {
 
 // DayOfYear gets day of year like 365.
 // 获取本年的第几天
-func (c Carbon) DayOfYear() int {
+func (c *Carbon) DayOfYear() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -54,7 +54,7 @@ func (c Carbon) DayOfYear() int {
 
 // DayOfMonth gets day of month like 30.
 // 获取本月的第几天
-func (c Carbon) DayOfMonth() int {
+func (c *Carbon) DayOfMonth() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -63,7 +63,7 @@ func (c Carbon) DayOfMonth() int {
 
 // DayOfWeek gets day of week like 6.
 // 获取本周的第几天
-func (c Carbon) DayOfWeek() int {
+func (c *Carbon) DayOfWeek() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -76,7 +76,7 @@ func (c Carbon) DayOfWeek() int {
 
 // WeekOfYear gets week of year like 1, see https://en.wikipedia.org/wiki/ISO_8601#Week_dates.
 // 获取本年的第几周
-func (c Carbon) WeekOfYear() int {
+func (c *Carbon) WeekOfYear() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -86,7 +86,7 @@ func (c Carbon) WeekOfYear() int {
 
 // WeekOfMonth gets week of month like 1.
 // 获取本月的第几周
-func (c Carbon) WeekOfMonth() int {
+func (c *Carbon) WeekOfMonth() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -99,7 +99,7 @@ func (c Carbon) WeekOfMonth() int {
 
 // DateTime gets current year, month, day, hour, minute, and second like 2020, 8, 5, 13, 14, 15.
 // 获取当前年、月、日、时、分、秒
-func (c Carbon) DateTime() (year, month, day, hour, minute, second int) {
+func (c *Carbon) DateTime() (year, month, day, hour, minute, second int) {
 	if c.Error != nil {
 		return
 	}
@@ -110,7 +110,7 @@ func (c Carbon) DateTime() (year, month, day, hour, minute, second int) {
 
 // DateTimeMilli gets current year, month, day, hour, minute, second and millisecond like 2020, 8, 5, 13, 14, 15, 999.
 // 获取当前年、月、日、时、分、秒、毫秒
-func (c Carbon) DateTimeMilli() (year, month, day, hour, minute, second, millisecond int) {
+func (c *Carbon) DateTimeMilli() (year, month, day, hour, minute, second, millisecond int) {
 	if c.Error != nil {
 		return
 	}
@@ -120,7 +120,7 @@ func (c Carbon) DateTimeMilli() (year, month, day, hour, minute, second, millise
 
 // DateTimeMicro gets current year, month, day, hour, minute, second and microsecond like 2020, 8, 5, 13, 14, 15, 999999.
 // 获取当前年、月、日、时、分、秒、微秒
-func (c Carbon) DateTimeMicro() (year, month, day, hour, minute, second, microsecond int) {
+func (c *Carbon) DateTimeMicro() (year, month, day, hour, minute, second, microsecond int) {
 	if c.Error != nil {
 		return
 	}
@@ -130,7 +130,7 @@ func (c Carbon) DateTimeMicro() (year, month, day, hour, minute, second, microse
 
 // DateTimeNano gets current year, month, day, hour, minute, second and nanosecond like 2020, 8, 5, 13, 14, 15, 999999999.
 // 获取当前年、月、日、时、分、秒、纳秒
-func (c Carbon) DateTimeNano() (year, month, day, hour, minute, second, nanosecond int) {
+func (c *Carbon) DateTimeNano() (year, month, day, hour, minute, second, nanosecond int) {
 	if c.Error != nil {
 		return
 	}
@@ -140,7 +140,7 @@ func (c Carbon) DateTimeNano() (year, month, day, hour, minute, second, nanoseco
 
 // Date gets current year, month, and day like 2020, 8, 5.
 // 获取当前年、月、日
-func (c Carbon) Date() (year, month, day int) {
+func (c *Carbon) Date() (year, month, day int) {
 	if c.Error != nil {
 		return
 	}
@@ -151,7 +151,7 @@ func (c Carbon) Date() (year, month, day int) {
 
 // DateMilli gets current year, month, day and millisecond like 2020, 8, 5, 999.
 // 获取当前年、月、日、毫秒
-func (c Carbon) DateMilli() (year, month, day, millisecond int) {
+func (c *Carbon) DateMilli() (year, month, day, millisecond int) {
 	if c.Error != nil {
 		return
 	}
@@ -161,7 +161,7 @@ func (c Carbon) DateMilli() (year, month, day, millisecond int) {
 
 // DateMicro gets current year, month, day and microsecond like 2020, 8, 5, 999999.
 // 获取当前年、月、日、微秒
-func (c Carbon) DateMicro() (year, month, day, microsecond int) {
+func (c *Carbon) DateMicro() (year, month, day, microsecond int) {
 	if c.Error != nil {
 		return
 	}
@@ -171,7 +171,7 @@ func (c Carbon) DateMicro() (year, month, day, microsecond int) {
 
 // DateNano gets current year, month, day and nanosecond like 2020, 8, 5, 999999999.
 // 获取当前年、月、日、纳秒
-func (c Carbon) DateNano() (year, month, day, nanosecond int) {
+func (c *Carbon) DateNano() (year, month, day, nanosecond int) {
 	if c.Error != nil {
 		return
 	}
@@ -181,7 +181,7 @@ func (c Carbon) DateNano() (year, month, day, nanosecond int) {
 
 // Time gets current hour, minute, and second like 13, 14, 15.
 // 获取当前时、分、秒
-func (c Carbon) Time() (hour, minute, second int) {
+func (c *Carbon) Time() (hour, minute, second int) {
 	if c.Error != nil {
 		return
 	}
@@ -190,7 +190,7 @@ func (c Carbon) Time() (hour, minute, second int) {
 
 // TimeMilli gets current hour, minute, second and millisecond like 13, 14, 15, 999.
 // 获取当前时、分、秒、毫秒
-func (c Carbon) TimeMilli() (hour, minute, second, millisecond int) {
+func (c *Carbon) TimeMilli() (hour, minute, second, millisecond int) {
 	if c.Error != nil {
 		return
 	}
@@ -200,7 +200,7 @@ func (c Carbon) TimeMilli() (hour, minute, second, millisecond int) {
 
 // TimeMicro gets current hour, minute, second and microsecond like 13, 14, 15, 999999.
 // 获取当前时、分、秒、微秒
-func (c Carbon) TimeMicro() (hour, minute, second, microsecond int) {
+func (c *Carbon) TimeMicro() (hour, minute, second, microsecond int) {
 	if c.Error != nil {
 		return
 	}
@@ -210,7 +210,7 @@ func (c Carbon) TimeMicro() (hour, minute, second, microsecond int) {
 
 // TimeNano gets current hour, minute, second and nanosecond like 13, 14, 15, 999999999.
 // 获取当前时、分、秒、纳秒
-func (c Carbon) TimeNano() (hour, minute, second, nanosecond int) {
+func (c *Carbon) TimeNano() (hour, minute, second, nanosecond int) {
 	if c.Error != nil {
 		return
 	}
@@ -220,7 +220,7 @@ func (c Carbon) TimeNano() (hour, minute, second, nanosecond int) {
 
 // Century gets current century like 21.
 // 获取当前世纪
-func (c Carbon) Century() int {
+func (c *Carbon) Century() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -229,7 +229,7 @@ func (c Carbon) Century() int {
 
 // Decade gets current decade like 20.
 // 获取当前年代
-func (c Carbon) Decade() int {
+func (c *Carbon) Decade() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -238,7 +238,7 @@ func (c Carbon) Decade() int {
 
 // Year gets current year like 2020.
 // 获取当前年
-func (c Carbon) Year() int {
+func (c *Carbon) Year() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -247,7 +247,7 @@ func (c Carbon) Year() int {
 
 // Quarter gets current quarter like 3.
 // 获取当前季度
-func (c Carbon) Quarter() (quarter int) {
+func (c *Carbon) Quarter() (quarter int) {
 	if c.Error != nil {
 		return
 	}
@@ -267,13 +267,13 @@ func (c Carbon) Quarter() (quarter int) {
 
 // Month gets current month like 8.
 // 获取当前月
-func (c Carbon) Month() int {
+func (c *Carbon) Month() int {
 	return c.MonthOfYear()
 }
 
 // Week gets current week like 6, start from 0.
 // 获取当前周(从0开始)
-func (c Carbon) Week() int {
+func (c *Carbon) Week() int {
 	if c.Error != nil {
 		return -1
 	}
@@ -282,13 +282,13 @@ func (c Carbon) Week() int {
 
 // Day gets current day like 5.
 // 获取当前日
-func (c Carbon) Day() int {
+func (c *Carbon) Day() int {
 	return c.DayOfMonth()
 }
 
 // Hour gets current hour like 13.
 // 获取当前小时
-func (c Carbon) Hour() int {
+func (c *Carbon) Hour() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -297,7 +297,7 @@ func (c Carbon) Hour() int {
 
 // Minute gets current minute like 14.
 // 获取当前分钟数
-func (c Carbon) Minute() int {
+func (c *Carbon) Minute() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -306,7 +306,7 @@ func (c Carbon) Minute() int {
 
 // Second gets current second like 15.
 // 获取当前秒数
-func (c Carbon) Second() int {
+func (c *Carbon) Second() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -315,7 +315,7 @@ func (c Carbon) Second() int {
 
 // Millisecond gets current millisecond like 999.
 // 获取当前毫秒数
-func (c Carbon) Millisecond() int {
+func (c *Carbon) Millisecond() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -324,7 +324,7 @@ func (c Carbon) Millisecond() int {
 
 // Microsecond gets current microsecond like 999999.
 // 获取当前微秒数
-func (c Carbon) Microsecond() int {
+func (c *Carbon) Microsecond() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -333,7 +333,7 @@ func (c Carbon) Microsecond() int {
 
 // Nanosecond gets current nanosecond like 999999999.
 // 获取当前纳秒数
-func (c Carbon) Nanosecond() int {
+func (c *Carbon) Nanosecond() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -341,8 +341,8 @@ func (c Carbon) Nanosecond() int {
 }
 
 // Timestamp gets timestamp with second like 1596604455.
-// 输出秒级时间戳
-func (c Carbon) Timestamp() int64 {
+// 获取秒级时间戳
+func (c *Carbon) Timestamp() int64 {
 	if c.Error != nil {
 		return 0
 	}
@@ -351,7 +351,7 @@ func (c Carbon) Timestamp() int64 {
 
 // TimestampMilli gets timestamp with millisecond like 1596604455000.
 // 获取毫秒级时间戳
-func (c Carbon) TimestampMilli() int64 {
+func (c *Carbon) TimestampMilli() int64 {
 	if c.Error != nil {
 		return 0
 	}
@@ -361,7 +361,7 @@ func (c Carbon) TimestampMilli() int64 {
 
 // TimestampMicro gets timestamp with microsecond like 1596604455000000.
 // 获取微秒级时间戳
-func (c Carbon) TimestampMicro() int64 {
+func (c *Carbon) TimestampMicro() int64 {
 	if c.Error != nil {
 		return 0
 	}
@@ -371,7 +371,7 @@ func (c Carbon) TimestampMicro() int64 {
 
 // TimestampNano gets timestamp with nanosecond like 1596604455000000000.
 // 获取纳秒级时间戳
-func (c Carbon) TimestampNano() int64 {
+func (c *Carbon) TimestampNano() int64 {
 	if c.Error != nil {
 		return 0
 	}
@@ -380,7 +380,7 @@ func (c Carbon) TimestampNano() int64 {
 
 // Location gets location name like "PRC".
 // 获取位置
-func (c Carbon) Location() string {
+func (c *Carbon) Location() string {
 	if c.Error != nil {
 		return ""
 	}
@@ -389,7 +389,7 @@ func (c Carbon) Location() string {
 
 // Timezone gets timezone name like "CST".
 // 获取时区
-func (c Carbon) Timezone() string {
+func (c *Carbon) Timezone() string {
 	if c.Error != nil {
 		return ""
 	}
@@ -399,7 +399,7 @@ func (c Carbon) Timezone() string {
 
 // Offset gets offset seconds from the UTC timezone like 28800.
 // 获取距离UTC时区的偏移量，单位秒
-func (c Carbon) Offset() int {
+func (c *Carbon) Offset() int {
 	if c.Error != nil {
 		return 0
 	}
@@ -409,7 +409,7 @@ func (c Carbon) Offset() int {
 
 // Locale gets locale name like "zh-CN".
 // 获取语言区域
-func (c Carbon) Locale() string {
+func (c *Carbon) Locale() string {
 	if c.Error != nil {
 		return ""
 	}
@@ -418,7 +418,7 @@ func (c Carbon) Locale() string {
 
 // Age gets age like 18.
 // 获取年龄
-func (c Carbon) Age() int {
+func (c *Carbon) Age() int {
 	if c.Error != nil {
 		return 0
 	}

--- a/getter_unit_test.go
+++ b/getter_unit_test.go
@@ -16,7 +16,7 @@ func TestCarbon_StdTime(t *testing.T) {
 func TestCarbon_DaysInYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -46,7 +46,7 @@ func TestCarbon_DaysInYear(t *testing.T) {
 func TestCarbon_DaysInMonth(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -86,7 +86,7 @@ func TestCarbon_DaysInMonth(t *testing.T) {
 func TestCarbon_MonthOfYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -126,7 +126,7 @@ func TestCarbon_MonthOfYear(t *testing.T) {
 func TestCarbon_DayOfYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -166,7 +166,7 @@ func TestCarbon_DayOfYear(t *testing.T) {
 func TestCarbon_DayOfMonth(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -206,7 +206,7 @@ func TestCarbon_DayOfMonth(t *testing.T) {
 func TestCarbon_DayOfWeek(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -246,7 +246,7 @@ func TestCarbon_DayOfWeek(t *testing.T) {
 func TestCarbon_WeekOfYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -291,7 +291,7 @@ func TestCarbon_WeekOfYear(t *testing.T) {
 func TestCarbon_WeekOfMonth(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -346,7 +346,7 @@ func TestCarbon_WeekOfMonth(t *testing.T) {
 func TestCarbon_DateTime(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			year, month, day, hour, minute, second int
 		}
@@ -389,7 +389,7 @@ func TestCarbon_DateTime(t *testing.T) {
 func TestCarbon_DateTimeMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			year, month, day, hour, minute, second, millisecond int
 		}
@@ -438,7 +438,7 @@ func TestCarbon_DateTimeMilli(t *testing.T) {
 func TestCarbon_DateTimeMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			year, month, day, hour, minute, second, microsecond int
 		}
@@ -482,7 +482,7 @@ func TestCarbon_DateTimeMicro(t *testing.T) {
 func TestCarbon_DateTimeNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			year, month, day, hour, minute, second, nanosecond int
 		}
@@ -526,7 +526,7 @@ func TestCarbon_DateTimeNano(t *testing.T) {
 func TestCarbon_Date(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			year, month, day int
 		}
@@ -561,7 +561,7 @@ func TestCarbon_Date(t *testing.T) {
 func TestCarbon_DateMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			year, month, day, millisecond int
 		}
@@ -597,7 +597,7 @@ func TestCarbon_DateMilli(t *testing.T) {
 func TestCarbon_DateMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			year, month, day, microsecond int
 		}
@@ -633,7 +633,7 @@ func TestCarbon_DateMicro(t *testing.T) {
 func TestCarbon_DateNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			year, month, day, nanosecond int
 		}
@@ -669,7 +669,7 @@ func TestCarbon_DateNano(t *testing.T) {
 func TestCarbon_Time(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			hour, minute, second int
 		}
@@ -704,7 +704,7 @@ func TestCarbon_Time(t *testing.T) {
 func TestCarbon_TimeMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			hour, minute, second, millisecond int
 		}
@@ -740,7 +740,7 @@ func TestCarbon_TimeMilli(t *testing.T) {
 func TestCarbon_TimeMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			hour, minute, second, microsecond int
 		}
@@ -776,7 +776,7 @@ func TestCarbon_TimeMicro(t *testing.T) {
 func TestCarbon_TimeNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   struct {
 			hour, minute, second, nanosecond int
 		}
@@ -812,7 +812,7 @@ func TestCarbon_TimeNano(t *testing.T) {
 func TestCarbon_Century(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -842,7 +842,7 @@ func TestCarbon_Century(t *testing.T) {
 func TestCarbon_Decade(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -882,7 +882,7 @@ func TestCarbon_Decade(t *testing.T) {
 func TestCarbon_Year(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -912,7 +912,7 @@ func TestCarbon_Year(t *testing.T) {
 func TestCarbon_Quarter(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -952,7 +952,7 @@ func TestCarbon_Quarter(t *testing.T) {
 func TestCarbon_Month(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -982,7 +982,7 @@ func TestCarbon_Month(t *testing.T) {
 func TestCarbon_Week(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -1027,7 +1027,7 @@ func TestCarbon_Week(t *testing.T) {
 func TestCarbon_Day(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -1062,7 +1062,7 @@ func TestCarbon_Day(t *testing.T) {
 func TestCarbon_Hour(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -1097,7 +1097,7 @@ func TestCarbon_Hour(t *testing.T) {
 func TestCarbon_Minute(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -1132,7 +1132,7 @@ func TestCarbon_Minute(t *testing.T) {
 func TestCarbon_Second(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -1167,7 +1167,7 @@ func TestCarbon_Second(t *testing.T) {
 func TestCarbon_Millisecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -1212,7 +1212,7 @@ func TestCarbon_Millisecond(t *testing.T) {
 func TestCarbon_Microsecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -1257,7 +1257,7 @@ func TestCarbon_Microsecond(t *testing.T) {
 func TestCarbon_Nanosecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -1302,7 +1302,7 @@ func TestCarbon_Nanosecond(t *testing.T) {
 func TestCarbon_Timestamp(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int64
 	}{
 		{
@@ -1347,7 +1347,7 @@ func TestCarbon_Timestamp(t *testing.T) {
 func TestCarbon_TimestampMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int64
 	}{
 		{
@@ -1392,7 +1392,7 @@ func TestCarbon_TimestampMilli(t *testing.T) {
 func TestCarbon_TimestampMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int64
 	}{
 		{
@@ -1437,7 +1437,7 @@ func TestCarbon_TimestampMicro(t *testing.T) {
 func TestCarbon_TimestampNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int64
 	}{
 		{
@@ -1482,7 +1482,7 @@ func TestCarbon_TimestampNano(t *testing.T) {
 func TestCarbon_Timezone(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1517,7 +1517,7 @@ func TestCarbon_Timezone(t *testing.T) {
 func TestCarbon_Location(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1552,7 +1552,7 @@ func TestCarbon_Location(t *testing.T) {
 func TestCarbon_Offset(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{
@@ -1587,7 +1587,7 @@ func TestCarbon_Offset(t *testing.T) {
 func TestCarbon_Locale(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1617,7 +1617,7 @@ func TestCarbon_Locale(t *testing.T) {
 func TestCarbon_Age(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   int
 	}{
 		{

--- a/language.go
+++ b/language.go
@@ -43,7 +43,7 @@ func NewLanguage() *Language {
 
 // SetLanguage sets language.
 // 设置语言对象
-func SetLanguage(lang *Language) Carbon {
+func SetLanguage(lang *Language) *Carbon {
 	c := NewCarbon()
 	lang.SetLocale(lang.locale)
 	c.lang, c.Error = lang, lang.Error

--- a/parser.go
+++ b/parser.go
@@ -7,7 +7,7 @@ import (
 
 // Parse parses a standard time string as a Carbon instance.
 // 将标准格式时间字符串解析成 Carbon 实例
-func (c Carbon) Parse(value string, timezone ...string) Carbon {
+func (c *Carbon) Parse(value string, timezone ...string) *Carbon {
 	if len(value) == 0 {
 		c.Error = invalidValueError(value)
 		return c
@@ -36,13 +36,13 @@ func (c Carbon) Parse(value string, timezone ...string) Carbon {
 
 // Parse parses a standard time string as a Carbon instance.
 // 将标准时间字符串解析成 Carbon 实例
-func Parse(value string, timezone ...string) Carbon {
+func Parse(value string, timezone ...string) *Carbon {
 	return NewCarbon().Parse(value, timezone...)
 }
 
 // ParseByFormat parses a time string as a Carbon instance by format.
 // 通过格式模板将时间字符串解析成 Carbon 实例
-func (c Carbon) ParseByFormat(value, format string, timezone ...string) Carbon {
+func (c *Carbon) ParseByFormat(value, format string, timezone ...string) *Carbon {
 	carbon := c.ParseByLayout(value, format2layout(format), timezone...)
 	if carbon.Error != nil {
 		carbon.Error = invalidFormatError(value, format)
@@ -52,13 +52,13 @@ func (c Carbon) ParseByFormat(value, format string, timezone ...string) Carbon {
 
 // ParseByFormat parses a time string as a Carbon instance by format.
 // 通过格式模板将时间字符串解析成 Carbon 实例
-func ParseByFormat(value, format string, timezone ...string) Carbon {
+func ParseByFormat(value, format string, timezone ...string) *Carbon {
 	return NewCarbon().ParseByFormat(value, format, timezone...)
 }
 
 // ParseByLayout parses a time string as a Carbon instance by layout.
 // 通过布局模板将时间字符串解析成 Carbon 实例
-func (c Carbon) ParseByLayout(value, layout string, timezone ...string) Carbon {
+func (c *Carbon) ParseByLayout(value, layout string, timezone ...string) *Carbon {
 	if len(value) == 0 {
 		c.Error = invalidValueError(value)
 		return c
@@ -99,6 +99,6 @@ func (c Carbon) ParseByLayout(value, layout string, timezone ...string) Carbon {
 
 // ParseByLayout parses a time string as a Carbon instance by layout.
 // 通过布局模板将时间字符串解析成 Carbon 实例
-func ParseByLayout(value, layout string, timezone ...string) Carbon {
+func ParseByLayout(value, layout string, timezone ...string) *Carbon {
 	return NewCarbon().ParseByLayout(value, layout, timezone...)
 }

--- a/parser_unit_test.go
+++ b/parser_unit_test.go
@@ -9,7 +9,7 @@ import (
 func TestCarbon_Parse(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -79,7 +79,7 @@ func TestCarbon_Parse(t *testing.T) {
 func TestCarbon_ParseByFormat(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -114,7 +114,7 @@ func TestCarbon_ParseByFormat(t *testing.T) {
 func TestCarbon_ParseByLayout(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -160,7 +160,7 @@ func TestError_ParseByFormat(t *testing.T) {
 func TestCarbon_Issue202(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -196,7 +196,7 @@ func TestCarbon_Issue202(t *testing.T) {
 func TestCarbon_Issue206(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -232,7 +232,7 @@ func TestCarbon_Issue206(t *testing.T) {
 func TestCarbon_Issue232(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{

--- a/season.go
+++ b/season.go
@@ -23,7 +23,7 @@ var seasons = []struct {
 
 // Season gets season name according to the meteorological division method like "Spring", i18n is supported.
 // 获取当前季节(以气象划分)，支持i18n
-func (c Carbon) Season() string {
+func (c *Carbon) Season() string {
 	if c.Error != nil {
 		return ""
 	}
@@ -51,7 +51,7 @@ func (c Carbon) Season() string {
 
 // StartOfSeason returns a Carbon instance for start of the season.
 // 本季节开始时间
-func (c Carbon) StartOfSeason() Carbon {
+func (c *Carbon) StartOfSeason() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -64,7 +64,7 @@ func (c Carbon) StartOfSeason() Carbon {
 
 // EndOfSeason returns a Carbon instance for end of the season.
 // 本季节结束时间
-func (c Carbon) EndOfSeason() Carbon {
+func (c *Carbon) EndOfSeason() *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -80,7 +80,7 @@ func (c Carbon) EndOfSeason() Carbon {
 
 // IsSpring reports whether is spring.
 // 是否是春季
-func (c Carbon) IsSpring() bool {
+func (c *Carbon) IsSpring() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -93,7 +93,7 @@ func (c Carbon) IsSpring() bool {
 
 // IsSummer reports whether is summer.
 // 是否是夏季
-func (c Carbon) IsSummer() bool {
+func (c *Carbon) IsSummer() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -106,7 +106,7 @@ func (c Carbon) IsSummer() bool {
 
 // IsAutumn reports whether is autumn.
 // 是否是秋季
-func (c Carbon) IsAutumn() bool {
+func (c *Carbon) IsAutumn() bool {
 	if c.Error != nil {
 		return false
 	}
@@ -119,7 +119,7 @@ func (c Carbon) IsAutumn() bool {
 
 // IsWinter reports whether is winter.
 // 是否是冬季
-func (c Carbon) IsWinter() bool {
+func (c *Carbon) IsWinter() bool {
 	if c.Error != nil {
 		return false
 	}

--- a/season_unit_test.go
+++ b/season_unit_test.go
@@ -9,7 +9,7 @@ import (
 func TestCarbon_Season(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -84,7 +84,7 @@ func TestCarbon_Season(t *testing.T) {
 func TestCarbon_StartOfSeason(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -164,7 +164,7 @@ func TestCarbon_StartOfSeason(t *testing.T) {
 func TestCarbon_EndOfSeason(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -244,7 +244,7 @@ func TestCarbon_EndOfSeason(t *testing.T) {
 func TestCarbon_IsSpring(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -274,7 +274,7 @@ func TestCarbon_IsSpring(t *testing.T) {
 func TestCarbon_IsSummer(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -304,7 +304,7 @@ func TestCarbon_IsSummer(t *testing.T) {
 func TestCarbon_IsAutumn(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{
@@ -334,7 +334,7 @@ func TestCarbon_IsAutumn(t *testing.T) {
 func TestCarbon_IsWinter(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   bool
 	}{
 		{

--- a/setter.go
+++ b/setter.go
@@ -6,7 +6,7 @@ import (
 
 // SetWeekStartsAt sets start day of the week.
 // 设置一周的开始日期
-func (c Carbon) SetWeekStartsAt(day string) Carbon {
+func (c *Carbon) SetWeekStartsAt(day string) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -18,13 +18,13 @@ func (c Carbon) SetWeekStartsAt(day string) Carbon {
 
 // SetWeekStartsAt sets start day of the week.
 // 设置一周的开始日期
-func SetWeekStartsAt(day string) Carbon {
+func SetWeekStartsAt(day string) *Carbon {
 	return NewCarbon().SetWeekStartsAt(day)
 }
 
 // SetTimezone sets timezone.
 // 设置时区
-func (c Carbon) SetTimezone(name string) Carbon {
+func (c *Carbon) SetTimezone(name string) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -34,13 +34,13 @@ func (c Carbon) SetTimezone(name string) Carbon {
 
 // SetTimezone sets timezone.
 // 设置时区
-func SetTimezone(name string) Carbon {
+func SetTimezone(name string) *Carbon {
 	return NewCarbon().SetTimezone(name)
 }
 
 // SetLocation sets location.
 // 设置地区
-func (c Carbon) SetLocation(loc *time.Location) Carbon {
+func (c *Carbon) SetLocation(loc *time.Location) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -53,13 +53,13 @@ func (c Carbon) SetLocation(loc *time.Location) Carbon {
 
 // SetLocation sets location.
 // 设置地区
-func SetLocation(loc *time.Location) Carbon {
+func SetLocation(loc *time.Location) *Carbon {
 	return NewCarbon().SetLocation(loc)
 }
 
 // SetLocale sets locale.
 // 设置语言区域
-func (c Carbon) SetLocale(locale string) Carbon {
+func (c *Carbon) SetLocale(locale string) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -70,7 +70,7 @@ func (c Carbon) SetLocale(locale string) Carbon {
 
 // SetLocale sets locale.
 // 设置语言区域
-func SetLocale(locale string) Carbon {
+func SetLocale(locale string) *Carbon {
 	c := NewCarbon()
 	c.lang.SetLocale(locale)
 	c.Error = c.lang.Error
@@ -79,16 +79,16 @@ func SetLocale(locale string) Carbon {
 
 // SetDateTime sets year, month, day, hour, minute and second.
 // 设置年、月、日、时、分、秒
-func (c Carbon) SetDateTime(year, month, day, hour, minute, second int) Carbon {
+func (c *Carbon) SetDateTime(year, month, day, hour, minute, second int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
-	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
+	return c.create(year, month, day, hour, minute, second, 0)
 }
 
 // SetDateTimeMilli sets year, month, day, hour, minute, second and millisecond.
 // 设置年、月、日、时、分、秒、毫秒
-func (c Carbon) SetDateTimeMilli(year, month, day, hour, minute, second, millisecond int) Carbon {
+func (c *Carbon) SetDateTimeMilli(year, month, day, hour, minute, second, millisecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -97,7 +97,7 @@ func (c Carbon) SetDateTimeMilli(year, month, day, hour, minute, second, millise
 
 // SetDateTimeMicro sets year, month, day, hour, minute, second and microsecond.
 // 设置年、月、日、时、分、秒、微秒
-func (c Carbon) SetDateTimeMicro(year, month, day, hour, minute, second, microsecond int) Carbon {
+func (c *Carbon) SetDateTimeMicro(year, month, day, hour, minute, second, microsecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -106,7 +106,7 @@ func (c Carbon) SetDateTimeMicro(year, month, day, hour, minute, second, microse
 
 // SetDateTimeNano sets year, month, day, hour, minute, second and nanosecond.
 // 设置年、月、日、时、分、秒、纳秒
-func (c Carbon) SetDateTimeNano(year, month, day, hour, minute, second, nanosecond int) Carbon {
+func (c *Carbon) SetDateTimeNano(year, month, day, hour, minute, second, nanosecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -115,17 +115,17 @@ func (c Carbon) SetDateTimeNano(year, month, day, hour, minute, second, nanoseco
 
 // SetDate sets year, month and day.
 // 设置年、月、日
-func (c Carbon) SetDate(year, month, day int) Carbon {
+func (c *Carbon) SetDate(year, month, day int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
 	hour, minute, second := c.Time()
-	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
+	return c.create(year, month, day, hour, minute, second, 0)
 }
 
 // SetDateMilli sets year, month, day and millisecond.
 // 设置年、月、日、毫秒
-func (c Carbon) SetDateMilli(year, month, day, millisecond int) Carbon {
+func (c *Carbon) SetDateMilli(year, month, day, millisecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -135,7 +135,7 @@ func (c Carbon) SetDateMilli(year, month, day, millisecond int) Carbon {
 
 // SetDateMicro sets year, month, day and microsecond.
 // 设置年、月、日、微秒
-func (c Carbon) SetDateMicro(year, month, day, microsecond int) Carbon {
+func (c *Carbon) SetDateMicro(year, month, day, microsecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -145,7 +145,7 @@ func (c Carbon) SetDateMicro(year, month, day, microsecond int) Carbon {
 
 // SetDateNano sets year, month, day and nanosecond.
 // 设置年、月、日、纳秒
-func (c Carbon) SetDateNano(year, month, day, nanosecond int) Carbon {
+func (c *Carbon) SetDateNano(year, month, day, nanosecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -155,17 +155,17 @@ func (c Carbon) SetDateNano(year, month, day, nanosecond int) Carbon {
 
 // SetTime sets hour, minute and second.
 // 设置时、分、秒
-func (c Carbon) SetTime(hour, minute, second int) Carbon {
+func (c *Carbon) SetTime(hour, minute, second int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
 	year, month, day := c.Date()
-	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
+	return c.create(year, month, day, hour, minute, second, 0)
 }
 
 // SetTimeMilli sets hour, minute, second and millisecond.
 // 设置时、分、秒、毫秒
-func (c Carbon) SetTimeMilli(hour, minute, second, millisecond int) Carbon {
+func (c *Carbon) SetTimeMilli(hour, minute, second, millisecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -175,7 +175,7 @@ func (c Carbon) SetTimeMilli(hour, minute, second, millisecond int) Carbon {
 
 // SetTimeMicro sets hour, minute, second and microsecond.
 // 设置时、分、秒、微秒
-func (c Carbon) SetTimeMicro(hour, minute, second, microsecond int) Carbon {
+func (c *Carbon) SetTimeMicro(hour, minute, second, microsecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -184,8 +184,8 @@ func (c Carbon) SetTimeMicro(hour, minute, second, microsecond int) Carbon {
 }
 
 // SetTimeNano sets hour, minute, second and nanosecond.
-// 设置、时、分、秒、纳秒
-func (c Carbon) SetTimeNano(hour, minute, second, nanosecond int) Carbon {
+// 设置时、分、秒、纳秒
+func (c *Carbon) SetTimeNano(hour, minute, second, nanosecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -195,17 +195,17 @@ func (c Carbon) SetTimeNano(hour, minute, second, nanosecond int) Carbon {
 
 // SetYear sets year.
 // 设置年份
-func (c Carbon) SetYear(year int) Carbon {
+func (c *Carbon) SetYear(year int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
 	_, month, day, hour, minute, second := c.DateTime()
-	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
+	return c.create(year, month, day, hour, minute, second, 0)
 }
 
 // SetYearNoOverflow sets year without overflowing month.
 // 设置年份(月份不溢出)
-func (c Carbon) SetYearNoOverflow(year int) Carbon {
+func (c *Carbon) SetYearNoOverflow(year int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -214,17 +214,17 @@ func (c Carbon) SetYearNoOverflow(year int) Carbon {
 
 // SetMonth sets month.
 // 设置月份
-func (c Carbon) SetMonth(month int) Carbon {
+func (c *Carbon) SetMonth(month int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
 	year, _, day, hour, minute, second := c.DateTime()
-	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
+	return c.create(year, month, day, hour, minute, second, 0)
 }
 
 // SetMonthNoOverflow sets month without overflowing month.
 // 设置月份(月份不溢出)
-func (c Carbon) SetMonthNoOverflow(month int) Carbon {
+func (c *Carbon) SetMonthNoOverflow(month int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -233,47 +233,47 @@ func (c Carbon) SetMonthNoOverflow(month int) Carbon {
 
 // SetDay sets day.
 // 设置日期
-func (c Carbon) SetDay(day int) Carbon {
+func (c *Carbon) SetDay(day int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
 	year, month, _, hour, minute, second := c.DateTime()
-	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
+	return c.create(year, month, day, hour, minute, second, 0)
 }
 
 // SetHour sets hour.
 // 设置小时
-func (c Carbon) SetHour(hour int) Carbon {
+func (c *Carbon) SetHour(hour int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
 	year, month, day, _, minute, second := c.DateTime()
-	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
+	return c.create(year, month, day, hour, minute, second, 0)
 }
 
 // SetMinute sets minute.
 // 设置分钟
-func (c Carbon) SetMinute(minute int) Carbon {
+func (c *Carbon) SetMinute(minute int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
 	year, month, day, hour, _, second := c.DateTime()
-	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
+	return c.create(year, month, day, hour, minute, second, 0)
 }
 
 // SetSecond sets second.
 // 设置秒数
-func (c Carbon) SetSecond(second int) Carbon {
+func (c *Carbon) SetSecond(second int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
 	year, month, day, hour, minute, _ := c.DateTime()
-	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
+	return c.create(year, month, day, hour, minute, second, 0)
 }
 
 // SetMillisecond sets millisecond.
 // 设置毫秒
-func (c Carbon) SetMillisecond(millisecond int) Carbon {
+func (c *Carbon) SetMillisecond(millisecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -283,7 +283,7 @@ func (c Carbon) SetMillisecond(millisecond int) Carbon {
 
 // SetMicrosecond sets microsecond.
 // 设置微秒
-func (c Carbon) SetMicrosecond(microsecond int) Carbon {
+func (c *Carbon) SetMicrosecond(microsecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}
@@ -293,7 +293,7 @@ func (c Carbon) SetMicrosecond(microsecond int) Carbon {
 
 // SetNanosecond sets nanosecond.
 // 设置纳秒
-func (c Carbon) SetNanosecond(nanosecond int) Carbon {
+func (c *Carbon) SetNanosecond(nanosecond int) *Carbon {
 	if c.Error != nil {
 		return c
 	}

--- a/setter.go
+++ b/setter.go
@@ -83,7 +83,7 @@ func (c *Carbon) SetDateTime(year, month, day, hour, minute, second int) *Carbon
 	if c.Error != nil {
 		return c
 	}
-	return c.create(year, month, day, hour, minute, second, 0)
+	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
 }
 
 // SetDateTimeMilli sets year, month, day, hour, minute, second and millisecond.
@@ -120,7 +120,7 @@ func (c *Carbon) SetDate(year, month, day int) *Carbon {
 		return c
 	}
 	hour, minute, second := c.Time()
-	return c.create(year, month, day, hour, minute, second, 0)
+	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
 }
 
 // SetDateMilli sets year, month, day and millisecond.
@@ -160,7 +160,7 @@ func (c *Carbon) SetTime(hour, minute, second int) *Carbon {
 		return c
 	}
 	year, month, day := c.Date()
-	return c.create(year, month, day, hour, minute, second, 0)
+	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
 }
 
 // SetTimeMilli sets hour, minute, second and millisecond.
@@ -200,7 +200,7 @@ func (c *Carbon) SetYear(year int) *Carbon {
 		return c
 	}
 	_, month, day, hour, minute, second := c.DateTime()
-	return c.create(year, month, day, hour, minute, second, 0)
+	return c.create(year, month, day, hour, minute, second, c.Nanosecond())
 }
 
 // SetYearNoOverflow sets year without overflowing month.

--- a/setter_unit_test.go
+++ b/setter_unit_test.go
@@ -10,7 +10,7 @@ import (
 func TestCarbon_SetWeekStartsAt(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -75,7 +75,7 @@ func TestCarbon_SetWeekStartsAt(t *testing.T) {
 func TestCarbon_SetTimezone(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -115,7 +115,7 @@ func TestCarbon_SetTimezone(t *testing.T) {
 func TestCarbon_SetLocation(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -160,7 +160,7 @@ func TestCarbon_SetLocation(t *testing.T) {
 func TestCarbon_SetLocale(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -205,7 +205,7 @@ func TestCarbon_SetLocale(t *testing.T) {
 func TestCarbon_SetDateTime(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -240,7 +240,7 @@ func TestCarbon_SetDateTime(t *testing.T) {
 func TestCarbon_SetDateTimeMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -275,7 +275,7 @@ func TestCarbon_SetDateTimeMilli(t *testing.T) {
 func TestCarbon_SetDateTimeMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -310,7 +310,7 @@ func TestCarbon_SetDateTimeMicro(t *testing.T) {
 func TestCarbon_SetDateTimeNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -345,7 +345,7 @@ func TestCarbon_SetDateTimeNano(t *testing.T) {
 func TestCarbon_SetDate(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -380,7 +380,7 @@ func TestCarbon_SetDate(t *testing.T) {
 func TestCarbon_SetDateMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -415,7 +415,7 @@ func TestCarbon_SetDateMilli(t *testing.T) {
 func TestCarbon_SetDateMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -450,7 +450,7 @@ func TestCarbon_SetDateMicro(t *testing.T) {
 func TestCarbon_SetDateNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -485,7 +485,7 @@ func TestCarbon_SetDateNano(t *testing.T) {
 func TestCarbon_SetTime(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -520,7 +520,7 @@ func TestCarbon_SetTime(t *testing.T) {
 func TestCarbon_SetTimeMilli(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -555,7 +555,7 @@ func TestCarbon_SetTimeMilli(t *testing.T) {
 func TestCarbon_SetTimeMicro(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -590,7 +590,7 @@ func TestCarbon_SetTimeMicro(t *testing.T) {
 func TestCarbon_SetTimeNano(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -625,7 +625,7 @@ func TestCarbon_SetTimeNano(t *testing.T) {
 func TestCarbon_SetYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -665,7 +665,7 @@ func TestCarbon_SetYear(t *testing.T) {
 func TestCarbon_SetYearNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -705,7 +705,7 @@ func TestCarbon_SetYearNoOverflow(t *testing.T) {
 func TestCarbon_SetMonth(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -745,7 +745,7 @@ func TestCarbon_SetMonth(t *testing.T) {
 func TestCarbon_SetMonthNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -785,7 +785,7 @@ func TestCarbon_SetMonthNoOverflow(t *testing.T) {
 func TestCarbon_SetDay(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -825,7 +825,7 @@ func TestCarbon_SetDay(t *testing.T) {
 func TestCarbon_SetHour(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -865,7 +865,7 @@ func TestCarbon_SetHour(t *testing.T) {
 func TestCarbon_SetMinute(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -905,7 +905,7 @@ func TestCarbon_SetMinute(t *testing.T) {
 func TestCarbon_SetSecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -945,7 +945,7 @@ func TestCarbon_SetSecond(t *testing.T) {
 func TestCarbon_SetMillisecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -985,7 +985,7 @@ func TestCarbon_SetMillisecond(t *testing.T) {
 func TestCarbon_SetMicrosecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1025,7 +1025,7 @@ func TestCarbon_SetMicrosecond(t *testing.T) {
 func TestCarbon_SetNanosecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{

--- a/test.go
+++ b/test.go
@@ -7,7 +7,7 @@ import (
 
 // SetTestNow sets a test Carbon instance (real or mock) to be returned when a "now" instance is created.
 // 设置当前测试时间
-func (c *Carbon) SetTestNow(carbon Carbon) {
+func (c *Carbon) SetTestNow(carbon *Carbon) {
 	c.testNow, c.loc = carbon.TimestampNano(), carbon.loc
 }
 
@@ -19,7 +19,7 @@ func (c *Carbon) UnSetTestNow() {
 
 // IsSetTestNow report whether there is testing time now.
 // 是否设置过当前测试时间
-func (c Carbon) IsSetTestNow() bool {
+func (c *Carbon) IsSetTestNow() bool {
 	return c.testNow > 0
 }
 

--- a/traveler.go
+++ b/traveler.go
@@ -6,7 +6,7 @@ import (
 
 // Now returns a Carbon instance for now.
 // 当前
-func (c Carbon) Now(timezone ...string) Carbon {
+func (c *Carbon) Now(timezone ...string) *Carbon {
 	if len(timezone) > 0 {
 		c.loc, c.Error = getLocationByTimezone(timezone[0])
 	}
@@ -24,13 +24,13 @@ func (c Carbon) Now(timezone ...string) Carbon {
 
 // Now returns a Carbon instance for now.
 // 当前
-func Now(timezone ...string) Carbon {
+func Now(timezone ...string) *Carbon {
 	return NewCarbon().Now(timezone...)
 }
 
 // Tomorrow returns a Carbon instance for tomorrow.
 // 明天
-func (c Carbon) Tomorrow(timezone ...string) Carbon {
+func (c *Carbon) Tomorrow(timezone ...string) *Carbon {
 	if len(timezone) > 0 {
 		c.loc, c.Error = getLocationByTimezone(timezone[0])
 	}
@@ -45,13 +45,13 @@ func (c Carbon) Tomorrow(timezone ...string) Carbon {
 
 // Tomorrow returns a Carbon instance for tomorrow.
 // 明天
-func Tomorrow(timezone ...string) Carbon {
+func Tomorrow(timezone ...string) *Carbon {
 	return NewCarbon().Tomorrow(timezone...)
 }
 
 // Yesterday returns a Carbon instance for yesterday.
 // 昨天
-func (c Carbon) Yesterday(timezone ...string) Carbon {
+func (c *Carbon) Yesterday(timezone ...string) *Carbon {
 	if len(timezone) > 0 {
 		c.loc, c.Error = getLocationByTimezone(timezone[0])
 	}
@@ -66,13 +66,13 @@ func (c Carbon) Yesterday(timezone ...string) Carbon {
 
 // Yesterday returns a Carbon instance for yesterday.
 // 昨天
-func Yesterday(timezone ...string) Carbon {
+func Yesterday(timezone ...string) *Carbon {
 	return NewCarbon().Yesterday(timezone...)
 }
 
 // AddDuration adds one duration.
 // 按照时长增加时间,支持整数/浮点数和符号ns(纳秒)、us(微妙)、ms(毫秒)、s(秒)、m(分钟)、h(小时)的组合
-func (c Carbon) AddDuration(duration string) Carbon {
+func (c *Carbon) AddDuration(duration string) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -83,109 +83,109 @@ func (c Carbon) AddDuration(duration string) Carbon {
 
 // SubDuration subtracts one duration.
 // 按照时长减少时间,支持整数/浮点数和符号ns(纳秒)、us(微妙)、ms(毫秒)、s(秒)、m(分钟)、h(小时)的组合
-func (c Carbon) SubDuration(duration string) Carbon {
+func (c *Carbon) SubDuration(duration string) *Carbon {
 	return c.AddDuration("-" + duration)
 }
 
 // AddCenturies adds some centuries.
 // N个世纪后
-func (c Carbon) AddCenturies(centuries int) Carbon {
+func (c *Carbon) AddCenturies(centuries int) *Carbon {
 	return c.AddYears(centuries * YearsPerCentury)
 }
 
 // AddCenturiesNoOverflow adds some centuries without overflowing month.
 // N个世纪后(月份不溢出)
-func (c Carbon) AddCenturiesNoOverflow(centuries int) Carbon {
+func (c *Carbon) AddCenturiesNoOverflow(centuries int) *Carbon {
 	return c.AddYearsNoOverflow(centuries * YearsPerCentury)
 }
 
 // AddCentury adds one century.
 // 1个世纪后
-func (c Carbon) AddCentury() Carbon {
+func (c *Carbon) AddCentury() *Carbon {
 	return c.AddCenturies(1)
 }
 
 // AddCenturyNoOverflow adds one century without overflowing month.
 // 1个世纪后(月份不溢出)
-func (c Carbon) AddCenturyNoOverflow() Carbon {
+func (c *Carbon) AddCenturyNoOverflow() *Carbon {
 	return c.AddCenturiesNoOverflow(1)
 }
 
 // SubCenturies subtracts some centuries.
 // N个世纪前
-func (c Carbon) SubCenturies(centuries int) Carbon {
+func (c *Carbon) SubCenturies(centuries int) *Carbon {
 	return c.SubYears(centuries * YearsPerCentury)
 }
 
 // SubCenturiesNoOverflow subtracts some centuries without overflowing month.
 // N个世纪前(月份不溢出)
-func (c Carbon) SubCenturiesNoOverflow(centuries int) Carbon {
+func (c *Carbon) SubCenturiesNoOverflow(centuries int) *Carbon {
 	return c.SubYearsNoOverflow(centuries * YearsPerCentury)
 }
 
 // SubCentury subtracts one century.
 // 1个世纪前
-func (c Carbon) SubCentury() Carbon {
+func (c *Carbon) SubCentury() *Carbon {
 	return c.SubCenturies(1)
 }
 
 // SubCenturyNoOverflow subtracts one century without overflowing month.
 // 1个世纪前(月份不溢出)
-func (c Carbon) SubCenturyNoOverflow() Carbon {
+func (c *Carbon) SubCenturyNoOverflow() *Carbon {
 	return c.SubCenturiesNoOverflow(1)
 }
 
 // AddDecades adds some decades.
 // N个年代后
-func (c Carbon) AddDecades(decades int) Carbon {
+func (c *Carbon) AddDecades(decades int) *Carbon {
 	return c.AddYears(decades * YearsPerDecade)
 }
 
 // AddDecadesNoOverflow adds some decades without overflowing month.
 // N个年代后(月份不溢出)
-func (c Carbon) AddDecadesNoOverflow(decades int) Carbon {
+func (c *Carbon) AddDecadesNoOverflow(decades int) *Carbon {
 	return c.AddYearsNoOverflow(decades * YearsPerDecade)
 }
 
 // AddDecade adds one decade.
 // 1个年代后
-func (c Carbon) AddDecade() Carbon {
+func (c *Carbon) AddDecade() *Carbon {
 	return c.AddDecades(1)
 }
 
 // AddDecadeNoOverflow adds one decade without overflowing month.
 // 1个年代后(月份不溢出)
-func (c Carbon) AddDecadeNoOverflow() Carbon {
+func (c *Carbon) AddDecadeNoOverflow() *Carbon {
 	return c.AddDecadesNoOverflow(1)
 }
 
 // SubDecades subtracts some decades.
 // N个年代后
-func (c Carbon) SubDecades(decades int) Carbon {
+func (c *Carbon) SubDecades(decades int) *Carbon {
 	return c.SubYears(decades * YearsPerDecade)
 }
 
 // SubDecadesNoOverflow subtracts some decades without overflowing month.
 // N个年代后(月份不溢出)
-func (c Carbon) SubDecadesNoOverflow(decades int) Carbon {
+func (c *Carbon) SubDecadesNoOverflow(decades int) *Carbon {
 	return c.SubYearsNoOverflow(decades * YearsPerDecade)
 }
 
 // SubDecade subtracts one decade.
 // 1个年代后
-func (c Carbon) SubDecade() Carbon {
+func (c *Carbon) SubDecade() *Carbon {
 	return c.SubDecades(1)
 }
 
 // SubDecadeNoOverflow subtracts one decade without overflowing month.
 // 1个年代后(月份不溢出)
-func (c Carbon) SubDecadeNoOverflow() Carbon {
+func (c *Carbon) SubDecadeNoOverflow() *Carbon {
 	return c.SubDecadesNoOverflow(1)
 }
 
 // AddYears adds some years.
 // N年后
-func (c Carbon) AddYears(years int) Carbon {
+func (c *Carbon) AddYears(years int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -195,7 +195,7 @@ func (c Carbon) AddYears(years int) Carbon {
 
 // AddYearsNoOverflow adds some years without overflowing month.
 // N年后(月份不溢出)
-func (c Carbon) AddYearsNoOverflow(years int) Carbon {
+func (c *Carbon) AddYearsNoOverflow(years int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -211,19 +211,19 @@ func (c Carbon) AddYearsNoOverflow(years int) Carbon {
 
 // AddYear adds one year.
 // 1年后
-func (c Carbon) AddYear() Carbon {
+func (c *Carbon) AddYear() *Carbon {
 	return c.AddYears(1)
 }
 
 // AddYearNoOverflow adds one year without overflowing month.
 // 1年后(月份不溢出)
-func (c Carbon) AddYearNoOverflow() Carbon {
+func (c *Carbon) AddYearNoOverflow() *Carbon {
 	return c.AddYearsNoOverflow(1)
 }
 
 // SubYears subtracts some years.
 // N年前
-func (c Carbon) SubYears(years int) Carbon {
+func (c *Carbon) SubYears(years int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -232,73 +232,73 @@ func (c Carbon) SubYears(years int) Carbon {
 
 // SubYearsNoOverflow subtracts some years without overflowing month.
 // N年前(月份不溢出)
-func (c Carbon) SubYearsNoOverflow(years int) Carbon {
+func (c *Carbon) SubYearsNoOverflow(years int) *Carbon {
 	return c.AddYearsNoOverflow(-years)
 }
 
 // SubYear subtracts one year.
 // 1年前
-func (c Carbon) SubYear() Carbon {
+func (c *Carbon) SubYear() *Carbon {
 	return c.SubYears(1)
 }
 
 // SubYearNoOverflow subtracts one year without overflowing month.
 // 1年前(月份不溢出)
-func (c Carbon) SubYearNoOverflow() Carbon {
+func (c *Carbon) SubYearNoOverflow() *Carbon {
 	return c.SubYearsNoOverflow(1)
 }
 
 // AddQuarters adds some quarters
 // N个季度后
-func (c Carbon) AddQuarters(quarters int) Carbon {
+func (c *Carbon) AddQuarters(quarters int) *Carbon {
 	return c.AddMonths(quarters * MonthsPerQuarter)
 }
 
 // AddQuartersNoOverflow adds quarters without overflowing month.
 // N个季度后(月份不溢出)
-func (c Carbon) AddQuartersNoOverflow(quarters int) Carbon {
+func (c *Carbon) AddQuartersNoOverflow(quarters int) *Carbon {
 	return c.AddMonthsNoOverflow(quarters * MonthsPerQuarter)
 }
 
 // AddQuarter adds one quarter
 // 1个季度后
-func (c Carbon) AddQuarter() Carbon {
+func (c *Carbon) AddQuarter() *Carbon {
 	return c.AddQuarters(1)
 }
 
 // AddQuarterNoOverflow adds one quarter without overflowing month.
 // 1个季度后(月份不溢出)
-func (c Carbon) AddQuarterNoOverflow() Carbon {
+func (c *Carbon) AddQuarterNoOverflow() *Carbon {
 	return c.AddQuartersNoOverflow(1)
 }
 
 // SubQuarters subtracts some quarters.
 // N个季度前
-func (c Carbon) SubQuarters(quarters int) Carbon {
+func (c *Carbon) SubQuarters(quarters int) *Carbon {
 	return c.AddQuarters(-quarters)
 }
 
 // SubQuartersNoOverflow subtracts some quarters without overflowing month.
 // N个季度前(月份不溢出)
-func (c Carbon) SubQuartersNoOverflow(quarters int) Carbon {
+func (c *Carbon) SubQuartersNoOverflow(quarters int) *Carbon {
 	return c.AddMonthsNoOverflow(-quarters * MonthsPerQuarter)
 }
 
 // SubQuarter subtracts one quarter.
 // 1个季度前
-func (c Carbon) SubQuarter() Carbon {
+func (c *Carbon) SubQuarter() *Carbon {
 	return c.SubQuarters(1)
 }
 
 // SubQuarterNoOverflow subtracts one quarter without overflowing month.
 // 1个季度前(月份不溢出)
-func (c Carbon) SubQuarterNoOverflow() Carbon {
+func (c *Carbon) SubQuarterNoOverflow() *Carbon {
 	return c.SubQuartersNoOverflow(1)
 }
 
 // AddMonths adds some months.
 // N个月后
-func (c Carbon) AddMonths(months int) Carbon {
+func (c *Carbon) AddMonths(months int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -308,7 +308,7 @@ func (c Carbon) AddMonths(months int) Carbon {
 
 // AddMonthsNoOverflow adds some months without overflowing month.
 // N个月后(月份不溢出)
-func (c Carbon) AddMonthsNoOverflow(months int) Carbon {
+func (c *Carbon) AddMonthsNoOverflow(months int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -324,67 +324,67 @@ func (c Carbon) AddMonthsNoOverflow(months int) Carbon {
 
 // AddMonth adds one month.
 // 1个月后
-func (c Carbon) AddMonth() Carbon {
+func (c *Carbon) AddMonth() *Carbon {
 	return c.AddMonths(1)
 }
 
 // AddMonthNoOverflow adds one month without overflowing month.
 // 1个月后(月份不溢出)
-func (c Carbon) AddMonthNoOverflow() Carbon {
+func (c *Carbon) AddMonthNoOverflow() *Carbon {
 	return c.AddMonthsNoOverflow(1)
 }
 
 // SubMonths subtracts some months.
 // N个月前
-func (c Carbon) SubMonths(months int) Carbon {
+func (c *Carbon) SubMonths(months int) *Carbon {
 	return c.AddMonths(-months)
 }
 
 // SubMonthsNoOverflow subtracts some months without overflowing month.
 // N个月前(月份不溢出)
-func (c Carbon) SubMonthsNoOverflow(months int) Carbon {
+func (c *Carbon) SubMonthsNoOverflow(months int) *Carbon {
 	return c.AddMonthsNoOverflow(-months)
 }
 
 // SubMonth subtracts one month.
 // 1个月前
-func (c Carbon) SubMonth() Carbon {
+func (c *Carbon) SubMonth() *Carbon {
 	return c.SubMonths(1)
 }
 
 // SubMonthNoOverflow subtracts one month without overflowing month.
 // 1个月前(月份不溢出)
-func (c Carbon) SubMonthNoOverflow() Carbon {
+func (c *Carbon) SubMonthNoOverflow() *Carbon {
 	return c.SubMonthsNoOverflow(1)
 }
 
 // AddWeeks adds some weeks.
 // N周后
-func (c Carbon) AddWeeks(weeks int) Carbon {
+func (c *Carbon) AddWeeks(weeks int) *Carbon {
 	return c.AddDays(weeks * DaysPerWeek)
 }
 
 // AddWeek adds one week.
 // 1周后
-func (c Carbon) AddWeek() Carbon {
+func (c *Carbon) AddWeek() *Carbon {
 	return c.AddWeeks(1)
 }
 
 // SubWeeks subtracts some weeks.
 // N周前
-func (c Carbon) SubWeeks(weeks int) Carbon {
+func (c *Carbon) SubWeeks(weeks int) *Carbon {
 	return c.SubDays(weeks * DaysPerWeek)
 }
 
 // SubWeek subtracts one week.
 // 1周前
-func (c Carbon) SubWeek() Carbon {
+func (c *Carbon) SubWeek() *Carbon {
 	return c.SubWeeks(1)
 }
 
 // AddDays adds some days.
 // N天后
-func (c Carbon) AddDays(days int) Carbon {
+func (c *Carbon) AddDays(days int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -394,25 +394,25 @@ func (c Carbon) AddDays(days int) Carbon {
 
 // AddDay adds one day.
 // 1天后
-func (c Carbon) AddDay() Carbon {
+func (c *Carbon) AddDay() *Carbon {
 	return c.AddDays(1)
 }
 
 // SubDays subtracts some days.
 // N天前
-func (c Carbon) SubDays(days int) Carbon {
+func (c *Carbon) SubDays(days int) *Carbon {
 	return c.AddDays(-days)
 }
 
 // SubDay subtracts one day.
 // 1天前
-func (c Carbon) SubDay() Carbon {
+func (c *Carbon) SubDay() *Carbon {
 	return c.SubDays(1)
 }
 
 // AddHours adds some hours.
 // N小时后
-func (c Carbon) AddHours(hours int) Carbon {
+func (c *Carbon) AddHours(hours int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -423,25 +423,25 @@ func (c Carbon) AddHours(hours int) Carbon {
 
 // AddHour adds one hour.
 // 1小时后
-func (c Carbon) AddHour() Carbon {
+func (c *Carbon) AddHour() *Carbon {
 	return c.AddHours(1)
 }
 
 // SubHours subtracts some hours.
 // N小时前
-func (c Carbon) SubHours(hours int) Carbon {
+func (c *Carbon) SubHours(hours int) *Carbon {
 	return c.AddHours(-hours)
 }
 
 // SubHour subtracts one hour.
 // 1小时前
-func (c Carbon) SubHour() Carbon {
+func (c *Carbon) SubHour() *Carbon {
 	return c.SubHours(1)
 }
 
 // AddMinutes adds some minutes.
 // N分钟后
-func (c Carbon) AddMinutes(minutes int) Carbon {
+func (c *Carbon) AddMinutes(minutes int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -452,25 +452,25 @@ func (c Carbon) AddMinutes(minutes int) Carbon {
 
 // AddMinute adds one minute.
 // 1分钟后
-func (c Carbon) AddMinute() Carbon {
+func (c *Carbon) AddMinute() *Carbon {
 	return c.AddMinutes(1)
 }
 
 // SubMinutes subtracts some minutes.
 // N分钟前
-func (c Carbon) SubMinutes(minutes int) Carbon {
+func (c *Carbon) SubMinutes(minutes int) *Carbon {
 	return c.AddMinutes(-minutes)
 }
 
 // SubMinute subtracts one minute.
 // 1分钟前
-func (c Carbon) SubMinute() Carbon {
+func (c *Carbon) SubMinute() *Carbon {
 	return c.SubMinutes(1)
 }
 
 // AddSeconds adds some seconds.
 // N秒钟后
-func (c Carbon) AddSeconds(seconds int) Carbon {
+func (c *Carbon) AddSeconds(seconds int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -481,25 +481,25 @@ func (c Carbon) AddSeconds(seconds int) Carbon {
 
 // AddSecond adds one second.
 // 1秒钟后
-func (c Carbon) AddSecond() Carbon {
+func (c *Carbon) AddSecond() *Carbon {
 	return c.AddSeconds(1)
 }
 
 // SubSeconds subtracts some seconds.
 // N秒钟前
-func (c Carbon) SubSeconds(seconds int) Carbon {
+func (c *Carbon) SubSeconds(seconds int) *Carbon {
 	return c.AddSeconds(-seconds)
 }
 
 // SubSecond subtracts one second.
 // 1秒钟前
-func (c Carbon) SubSecond() Carbon {
+func (c *Carbon) SubSecond() *Carbon {
 	return c.SubSeconds(1)
 }
 
 // AddMilliseconds adds some milliseconds.
 // N毫秒后
-func (c Carbon) AddMilliseconds(milliseconds int) Carbon {
+func (c *Carbon) AddMilliseconds(milliseconds int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -510,25 +510,25 @@ func (c Carbon) AddMilliseconds(milliseconds int) Carbon {
 
 // AddMillisecond adds one millisecond.
 // 1毫秒后
-func (c Carbon) AddMillisecond() Carbon {
+func (c *Carbon) AddMillisecond() *Carbon {
 	return c.AddMilliseconds(1)
 }
 
 // SubMilliseconds subtracts some milliseconds.
 // N毫秒前
-func (c Carbon) SubMilliseconds(milliseconds int) Carbon {
+func (c *Carbon) SubMilliseconds(milliseconds int) *Carbon {
 	return c.AddMilliseconds(-milliseconds)
 }
 
 // SubMillisecond subtracts one millisecond.
 // 1毫秒前
-func (c Carbon) SubMillisecond() Carbon {
+func (c *Carbon) SubMillisecond() *Carbon {
 	return c.SubMilliseconds(1)
 }
 
 // AddMicroseconds adds some microseconds.
 // N微秒后
-func (c Carbon) AddMicroseconds(microseconds int) Carbon {
+func (c *Carbon) AddMicroseconds(microseconds int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -539,25 +539,25 @@ func (c Carbon) AddMicroseconds(microseconds int) Carbon {
 
 // AddMicrosecond adds one microsecond.
 // 1微秒后
-func (c Carbon) AddMicrosecond() Carbon {
+func (c *Carbon) AddMicrosecond() *Carbon {
 	return c.AddMicroseconds(1)
 }
 
 // SubMicroseconds subtracts some microseconds.
 // N微秒前
-func (c Carbon) SubMicroseconds(microseconds int) Carbon {
+func (c *Carbon) SubMicroseconds(microseconds int) *Carbon {
 	return c.AddMicroseconds(-microseconds)
 }
 
 // SubMicrosecond subtracts one microsecond.
 // 1微秒前
-func (c Carbon) SubMicrosecond() Carbon {
+func (c *Carbon) SubMicrosecond() *Carbon {
 	return c.SubMicroseconds(1)
 }
 
 // AddNanoseconds adds some nanoseconds.
 // N纳秒后
-func (c Carbon) AddNanoseconds(nanoseconds int) Carbon {
+func (c *Carbon) AddNanoseconds(nanoseconds int) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
@@ -568,18 +568,18 @@ func (c Carbon) AddNanoseconds(nanoseconds int) Carbon {
 
 // AddNanosecond adds one nanosecond.
 // 1纳秒后
-func (c Carbon) AddNanosecond() Carbon {
+func (c *Carbon) AddNanosecond() *Carbon {
 	return c.AddNanoseconds(1)
 }
 
 // SubNanoseconds subtracts some nanoseconds.
 // N纳秒前
-func (c Carbon) SubNanoseconds(nanoseconds int) Carbon {
+func (c *Carbon) SubNanoseconds(nanoseconds int) *Carbon {
 	return c.AddNanoseconds(-nanoseconds)
 }
 
 // SubNanosecond subtracts one nanosecond.
 // 1纳秒前
-func (c Carbon) SubNanosecond() Carbon {
+func (c *Carbon) SubNanosecond() *Carbon {
 	return c.SubNanoseconds(1)
 }

--- a/traveler_unit_test.go
+++ b/traveler_unit_test.go
@@ -10,7 +10,7 @@ import (
 func TestCarbon_Now(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -40,7 +40,7 @@ func TestCarbon_Now(t *testing.T) {
 func TestCarbon_Yesterday(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -75,7 +75,7 @@ func TestCarbon_Yesterday(t *testing.T) {
 func TestCarbon_Tomorrow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -110,7 +110,7 @@ func TestCarbon_Tomorrow(t *testing.T) {
 func TestCarbon_AddDuration(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -155,7 +155,7 @@ func TestCarbon_AddDuration(t *testing.T) {
 func TestCarbon_SubDuration(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -200,7 +200,7 @@ func TestCarbon_SubDuration(t *testing.T) {
 func TestCarbon_AddCenturies(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -245,7 +245,7 @@ func TestCarbon_AddCenturies(t *testing.T) {
 func TestCarbon_AddCenturiesNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -290,7 +290,7 @@ func TestCarbon_AddCenturiesNoOverflow(t *testing.T) {
 func TestCarbon_SubCenturies(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -335,7 +335,7 @@ func TestCarbon_SubCenturies(t *testing.T) {
 func TestCarbon_SubCenturiesNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -380,7 +380,7 @@ func TestCarbon_SubCenturiesNoOverflow(t *testing.T) {
 func TestCarbon_AddCentury(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -425,7 +425,7 @@ func TestCarbon_AddCentury(t *testing.T) {
 func TestCarbon_AddCenturyNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -470,7 +470,7 @@ func TestCarbon_AddCenturyNoOverflow(t *testing.T) {
 func TestCarbon_SubCentury(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -515,7 +515,7 @@ func TestCarbon_SubCentury(t *testing.T) {
 func TestCarbon_SubCenturyNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -560,7 +560,7 @@ func TestCarbon_SubCenturyNoOverflow(t *testing.T) {
 func TestCarbon_AddDecades(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -605,7 +605,7 @@ func TestCarbon_AddDecades(t *testing.T) {
 func TestCarbon_AddDecadesNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -650,7 +650,7 @@ func TestCarbon_AddDecadesNoOverflow(t *testing.T) {
 func TestCarbon_AddDecade(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -695,7 +695,7 @@ func TestCarbon_AddDecade(t *testing.T) {
 func TestCarbon_AddDecadeNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -740,7 +740,7 @@ func TestCarbon_AddDecadeNoOverflow(t *testing.T) {
 func TestCarbon_SubDecades(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -785,7 +785,7 @@ func TestCarbon_SubDecades(t *testing.T) {
 func TestCarbon_SubDecadesNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -830,7 +830,7 @@ func TestCarbon_SubDecadesNoOverflow(t *testing.T) {
 func TestCarbon_SubDecade(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -875,7 +875,7 @@ func TestCarbon_SubDecade(t *testing.T) {
 func TestCarbon_SubDecadeNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -920,7 +920,7 @@ func TestCarbon_SubDecadeNoOverflow(t *testing.T) {
 func TestCarbon_AddYears(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -965,7 +965,7 @@ func TestCarbon_AddYears(t *testing.T) {
 func TestCarbon_AddYearsNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1010,7 +1010,7 @@ func TestCarbon_AddYearsNoOverflow(t *testing.T) {
 func TestCarbon_SubYears(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1055,7 +1055,7 @@ func TestCarbon_SubYears(t *testing.T) {
 func TestCarbon_SubYearsNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1100,7 +1100,7 @@ func TestCarbon_SubYearsNoOverflow(t *testing.T) {
 func TestCarbon_AddYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1145,7 +1145,7 @@ func TestCarbon_AddYear(t *testing.T) {
 func TestCarbon_AddYearNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1190,7 +1190,7 @@ func TestCarbon_AddYearNoOverflow(t *testing.T) {
 func TestCarbon_SubYear(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1235,7 +1235,7 @@ func TestCarbon_SubYear(t *testing.T) {
 func TestCarbon_SubYearNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1280,7 +1280,7 @@ func TestCarbon_SubYearNoOverflow(t *testing.T) {
 func TestCarbon_AddQuarters(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1335,7 +1335,7 @@ func TestCarbon_AddQuarters(t *testing.T) {
 func TestCarbon_AddQuartersNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1390,7 +1390,7 @@ func TestCarbon_AddQuartersNoOverflow(t *testing.T) {
 func TestCarbon_SubQuarters(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1445,7 +1445,7 @@ func TestCarbon_SubQuarters(t *testing.T) {
 func TestCarbon_SubQuartersNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1500,7 +1500,7 @@ func TestCarbon_SubQuartersNoOverflow(t *testing.T) {
 func TestCarbon_AddQuarter(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1550,7 +1550,7 @@ func TestCarbon_AddQuarter(t *testing.T) {
 func TestCarbon_AddQuarterNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1600,7 +1600,7 @@ func TestCarbon_AddQuarterNoOverflow(t *testing.T) {
 func TestCarbon_SubQuarter(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1645,7 +1645,7 @@ func TestCarbon_SubQuarter(t *testing.T) {
 func TestCarbon_SubQuarterNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1690,7 +1690,7 @@ func TestCarbon_SubQuarterNoOverflow(t *testing.T) {
 func TestCarbon_AddMonths(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1735,7 +1735,7 @@ func TestCarbon_AddMonths(t *testing.T) {
 func TestCarbon_AddMonthsNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1780,7 +1780,7 @@ func TestCarbon_AddMonthsNoOverflow(t *testing.T) {
 func TestCarbon_SubMonths(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1810,7 +1810,7 @@ func TestCarbon_SubMonths(t *testing.T) {
 func TestCarbon_SubMonthsNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1840,7 +1840,7 @@ func TestCarbon_SubMonthsNoOverflow(t *testing.T) {
 func TestCarbon_AddMonth(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1885,7 +1885,7 @@ func TestCarbon_AddMonth(t *testing.T) {
 func TestCarbon_AddMonthNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1930,7 +1930,7 @@ func TestCarbon_AddMonthNoOverflow(t *testing.T) {
 func TestCarbon_SubMonth(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -1975,7 +1975,7 @@ func TestCarbon_SubMonth(t *testing.T) {
 func TestCarbon_SubMonthNoOverflow(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2020,7 +2020,7 @@ func TestCarbon_SubMonthNoOverflow(t *testing.T) {
 func TestCarbon_AddWeeks(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2050,7 +2050,7 @@ func TestCarbon_AddWeeks(t *testing.T) {
 func TestCarbon_SubWeeks(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2080,7 +2080,7 @@ func TestCarbon_SubWeeks(t *testing.T) {
 func TestCarbon_AddWeek(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2125,7 +2125,7 @@ func TestCarbon_AddWeek(t *testing.T) {
 func TestCarbon_SubWeek(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2170,7 +2170,7 @@ func TestCarbon_SubWeek(t *testing.T) {
 func TestCarbon_AddDays(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2200,7 +2200,7 @@ func TestCarbon_AddDays(t *testing.T) {
 func TestCarbon_SubDays(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2230,7 +2230,7 @@ func TestCarbon_SubDays(t *testing.T) {
 func TestCarbon_AddDay(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2275,7 +2275,7 @@ func TestCarbon_AddDay(t *testing.T) {
 func TestCarbon_SubDay(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2320,7 +2320,7 @@ func TestCarbon_SubDay(t *testing.T) {
 func TestCarbon_AddHours(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2350,7 +2350,7 @@ func TestCarbon_AddHours(t *testing.T) {
 func TestCarbon_SubHours(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2380,7 +2380,7 @@ func TestCarbon_SubHours(t *testing.T) {
 func TestCarbon_AddHour(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2405,7 +2405,7 @@ func TestCarbon_AddHour(t *testing.T) {
 func TestCarbon_SubHour(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2430,7 +2430,7 @@ func TestCarbon_SubHour(t *testing.T) {
 func TestCarbon_AddMinutes(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2460,7 +2460,7 @@ func TestCarbon_AddMinutes(t *testing.T) {
 func TestCarbon_SubMinutes(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2490,7 +2490,7 @@ func TestCarbon_SubMinutes(t *testing.T) {
 func TestCarbon_AddMinute(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2515,7 +2515,7 @@ func TestCarbon_AddMinute(t *testing.T) {
 func TestCarbon_SubMinute(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2540,7 +2540,7 @@ func TestCarbon_SubMinute(t *testing.T) {
 func TestCarbon_AddSeconds(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2570,7 +2570,7 @@ func TestCarbon_AddSeconds(t *testing.T) {
 func TestCarbon_SubSeconds(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2600,7 +2600,7 @@ func TestCarbon_SubSeconds(t *testing.T) {
 func TestCarbon_AddSecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2625,7 +2625,7 @@ func TestCarbon_AddSecond(t *testing.T) {
 func TestCarbon_SubSecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2650,7 +2650,7 @@ func TestCarbon_SubSecond(t *testing.T) {
 func TestCarbon_AddMilliseconds(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2680,7 +2680,7 @@ func TestCarbon_AddMilliseconds(t *testing.T) {
 func TestCarbon_SubMilliseconds(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2710,7 +2710,7 @@ func TestCarbon_SubMilliseconds(t *testing.T) {
 func TestCarbon_AddMillisecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2735,7 +2735,7 @@ func TestCarbon_AddMillisecond(t *testing.T) {
 func TestCarbon_SubMillisecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2760,7 +2760,7 @@ func TestCarbon_SubMillisecond(t *testing.T) {
 func TestCarbon_AddMicroseconds(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2790,7 +2790,7 @@ func TestCarbon_AddMicroseconds(t *testing.T) {
 func TestCarbon_SubMicroseconds(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2820,7 +2820,7 @@ func TestCarbon_SubMicroseconds(t *testing.T) {
 func TestCarbon_AddMicrosecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2845,7 +2845,7 @@ func TestCarbon_AddMicrosecond(t *testing.T) {
 func TestCarbon_SubMicrosecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2870,7 +2870,7 @@ func TestCarbon_SubMicrosecond(t *testing.T) {
 func TestCarbon_AddNanoseconds(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2900,7 +2900,7 @@ func TestCarbon_AddNanoseconds(t *testing.T) {
 func TestCarbon_SubNanoseconds(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2930,7 +2930,7 @@ func TestCarbon_SubNanoseconds(t *testing.T) {
 func TestCarbon_AddNanosecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{
@@ -2955,7 +2955,7 @@ func TestCarbon_AddNanosecond(t *testing.T) {
 func TestCarbon_SubNanosecond(t *testing.T) {
 	tests := []struct {
 		name   string
-		carbon Carbon
+		carbon *Carbon
 		want   string
 	}{
 		{


### PR DESCRIPTION
As per this issue #249 makes bundle size large because each call creates a new `Carbon` object

This pull request includes changes to the `Carbon` package to modify methods and tests to use pointer receivers instead of value receivers. This change ensures that any modifications within these methods directly affect the original `Carbon` instance, improving performance and consistency.

### Changes to method signatures:

* Updated `boundary.go` to change method receivers from value to pointer for methods like `StartOfCentury`, `EndOfCentury`, `StartOfDecade`, `EndOfDecade`, `StartOfYear`, `EndOfYear`, `StartOfQuarter`, `EndOfQuarter`, `StartOfMonth`, `EndOfMonth`, `StartOfWeek`, `EndOfWeek`, `StartOfDay`, `EndOfDay`, `StartOfHour`, `EndOfHour`, `StartOfMinute`, `EndOfMinute`, `StartOfSecond`, and `EndOfSecond`. [[1]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L5-R5) [[2]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L14-R14) [[3]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L23-R23) [[4]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L32-R32) [[5]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L41-R41) [[6]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L50-R50) [[7]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L59-R59) [[8]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L69-R69) [[9]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L85-R85) [[10]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L95-R95) [[11]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L105-R105) [[12]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L115-R115) [[13]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L125-R125) [[14]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L135-R135) [[15]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L145-R145) [[16]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L155-R155) [[17]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L165-R165) [[18]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L175-R175) [[19]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L185-R185) [[20]](diffhunk://#diff-4e3f898e295bfbb5ed24c2fb59e51407f257d6496dab93a9c246aeef2b04d997L195-R195)

### Changes to unit tests:

* Updated `boundary_unit_test.go` to change the `carbon` field in test structs from value to pointer for test functions like `TestCarbon_StartOfCentury`, `TestCarbon_EndOfCentury`, `TestCarbon_StartOfDecade`, `TestCarbon_EndOfDecade`, `TestCarbon_StartOfYear`, `TestCarbon_EndOfYear`, `TestCarbon_StartOfQuarter`, `TestCarbon_EndOfQuarter`, `TestCarbon_StartOfMonth`, `TestCarbon_EndOfMonth`, `TestCarbon_StartOfWeek`, `TestCarbon_EndOfWeek`, `TestCarbon_StartOfDay`, `TestCarbon_EndOfDay`, `TestCarbon_StartOfHour`, `TestCarbon_EndOfHour`, `TestCarbon_StartOfMinute`, `TestCarbon_EndOfMinute`, `TestCarbon_StartOfSecond`, and `TestCarbon_EndOfSecond`. [[1]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L12-R12) [[2]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L52-R52) [[3]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L92-R92) [[4]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L137-R137) [[5]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L182-R182) [[6]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L222-R222) [[7]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L262-R262) [[8]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L302-R302) [[9]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L352-R352) [[10]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L392-R392) [[11]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L432-R432) [[12]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L472-R472) [[13]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L512-R512) [[14]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L552-R552) [[15]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L592-R592) [[16]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L632-R632) [[17]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L682-R682) [[18]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L732-R732) [[19]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L772-R772) [[20]](diffhunk://#diff-8a751d8b09e9c849caa7ecc1a9a0dcb1beb34ec9a0ce5dc36465ad5875b73585L812-R812)

### Changes to `calendar.go`:

* Updated methods in `calendar.go` to use pointer receivers for `Lunar`, `Julian`, and `Persian` conversions, and changed the return type of `CreateFromLunar` and `CreateFromJulian` to pointers. [[1]](diffhunk://#diff-7d5b515acd9bc43799b68025f4daf330c82648bf6317557565f1b01465e79272L21-R28) [[2]](diffhunk://#diff-7d5b515acd9bc43799b68025f4daf330c82648bf6317557565f1b01465e79272L37-R44)