### PR TITLE
fix(outputer): Fix the bug that may cause out-of-bounds access when formatting time

### DIFF
--- a/outputer.go
+++ b/outputer.go
@@ -806,8 +806,11 @@ func (c *Carbon) Format(format string, timezone ...string) string {
 		} else {
 			switch format[i] {
 			case '\\': // raw output, no parse
-				buffer.WriteByte(format[i+1])
-				i++
+				// Ensure we don't go out of bounds
+				if i+1 < len(format) {
+					buffer.WriteByte(format[i+1])
+					i++
+				}
 				continue
 			case 'W': // week number of the year, ranging from 1-52
 				week := fmt.Sprintf("%d", c.WeekOfYear())

--- a/outputer_unit_test.go
+++ b/outputer_unit_test.go
@@ -1789,6 +1789,15 @@ func (s *OutputerSuite) TestCarbon_Format() {
 		s.Equal(inputTime.Format("2006-01-02 15:04:05.999999"), c.Format("Y-m-d H:i:s.v"))
 		s.Equal(inputTime.Format("2006-01-02 15:04:05.999999999"), c.Format("Y-m-d H:i:s.x"))
 	})
+
+	// https://github.com/dromara/carbon/issues/347
+	s.Run("issue347", func() {
+		c := Parse("2020-08-05 13:14:15")
+
+		s.Equal("2020-08-05", c.Format("Y-m-d\\"))
+		s.Empty(c.Format("\\"))
+		s.Equal("2020-08-05\\", c.Format("Y-m-d\\\\"))
+	})
 }
 
 func (s *OutputerSuite) TestFormat2Layout() {


### PR DESCRIPTION
Closes #347.

## Problem

`Carbon.Format` reads `format[i+1]` in the escape branch without checking the
bound, so any format string ending with a backslash panics:

```go
carbon.Parse("2020-08-05 13:14:15").Format("Y-m-d\\")
// panic: runtime error: index out of range [6] with length 6
```

`format2layout` handles the escape character the same way and was already
guarded in 64dcb40. `outputer.go` held the only other `[i+1]` in the package
and was missed, which is why `ParseByFormat` accepts such a string today while
`Format` crashes on it.

This is worth fixing because `Format` accepts an arbitrary string, so a format
value arriving from user input or from configuration crashes the process.

## Fix

The same guard as 64dcb40:

```go
case '\\': // raw output, no parse
	// Ensure we don't go out of bounds
	if i+1 < len(format) {
		buffer.WriteByte(format[i+1])
		i++
	}
	continue
```

A trailing escape character is now dropped, which is exactly what
`format2layout` already does, so the two agree on this input.

## Tests

Added an `issue347` sub-test to `TestCarbon_Format`, following the existing
`issue328` convention in that file:

| input | before | after |
| --- | --- | --- |
| `Format("Y-m-d\\")` | panic | `2020-08-05` |
| `Format("\\")` | panic | empty string |
| `Format("Y-m-d\\\\")` | `2020-08-05\` | `2020-08-05\` (unchanged) |

The sub-test panics without the fix and passes with it.

## Verification

```
go test ./...                                             all packages ok
go test -race ./...                                       all packages ok
go vet .                                                  clean
go test -coverprofile=coverage.txt -covermode=atomic ./...  100.0% of statements
TZ=UTC, America/New_York, Asia/Shanghai, Europe/Moscow    all packages ok
```

Statement coverage of the package stays at 100.0%. The change is a bounds
check with no platform-specific behaviour, so the ubuntu/macos/windows matrix
is unaffected.

No public API changed, and no existing test was modified.
