### PR TITLE
perf(language): Copy locale resources on write instead of on every SetLocale

### DIFF
--- a/language.go
+++ b/language.go
@@ -27,6 +27,7 @@ type Language struct {
 	dir       string
 	locale    string
 	resources map[string]string
+	shared    bool
 	Error     error
 	rw        *sync.RWMutex
 }
@@ -34,10 +35,9 @@ type Language struct {
 // NewLanguage returns a new Language instance.
 func NewLanguage() *Language {
 	return &Language{
-		dir:       "lang",
-		locale:    DefaultLocale,
-		resources: make(map[string]string),
-		rw:        new(sync.RWMutex),
+		dir:    "lang",
+		locale: DefaultLocale,
+		rw:     new(sync.RWMutex),
 	}
 }
 
@@ -57,8 +57,14 @@ func (lang *Language) Copy() *Language {
 	}
 
 	lang.rw.RLock()
-	resources := lang.resources
+	resources, shared := lang.resources, lang.shared
 	lang.rw.RUnlock()
+
+	// The cached resources are immutable, so a shared copy can stay shared.
+	if shared {
+		newLang.resources, newLang.shared = resources, true
+		return newLang
+	}
 
 	newLang.resources = make(map[string]string, len(resources))
 	for k, v := range resources {
@@ -85,8 +91,11 @@ func (lang *Language) SetLocale(locale string) *Language {
 	}
 	lang.rw.RUnlock()
 
-	fileName := fmt.Sprintf("%s/%s.json", lang.dir, locale)
-	load, _ := localeCache.LoadOrStore(fileName, new(cachedResources))
+	fileName := lang.dir + "/" + locale + ".json"
+	load, ok := localeCache.Load(fileName)
+	if !ok {
+		load, _ = localeCache.LoadOrStore(fileName, new(cachedResources))
+	}
 	entry := load.(*cachedResources)
 
 	entry.once.Do(func() {
@@ -106,16 +115,12 @@ func (lang *Language) SetLocale(locale string) *Language {
 		return lang
 	}
 
-	// Create a copy of the cached resources to avoid modifying the cache
-	// Pre-allocate with exact capacity for better memory efficiency
-	newResources := make(map[string]string, len(entry.resources))
-	for k, v := range entry.resources {
-		newResources[k] = v
-	}
-
+	// Share the cached resources instead of copying them, and mark them shared so
+	// that SetResources copies before it writes. This keeps the cache unmodified.
 	lang.rw.Lock()
 	lang.locale = locale
-	lang.resources = newResources
+	lang.resources = entry.resources
+	lang.shared = true
 	lang.rw.Unlock()
 
 	return lang
@@ -134,6 +139,15 @@ func (lang *Language) SetResources(resources map[string]string) *Language {
 	lang.rw.Lock()
 	defer lang.rw.Unlock()
 
+	// Copy on write: the resources may be shared with the cache or another instance.
+	if lang.shared || lang.resources == nil {
+		newResources := make(map[string]string, len(lang.resources)+len(resources))
+		for k, v := range lang.resources {
+			newResources[k] = v
+		}
+		lang.resources = newResources
+		lang.shared = false
+	}
 	for k, v := range resources {
 		lang.resources[k] = v
 	}

--- a/language_unit_test.go
+++ b/language_unit_test.go
@@ -191,6 +191,19 @@ func (s *LanguageSuite) TestLanguage_SetResources() {
 		s.Equal("Wed", Parse("2020-08-05").SetLanguage(lang).ToShortWeekString())
 	})
 
+	// https://github.com/dromara/carbon/issues/349
+	s.Run("issue349", func() {
+		lang1 := NewLanguage().SetLocale("en")
+		lang1.SetResources(map[string]string{
+			"months": "Ⅰ月|Ⅱ月|Ⅲ月|Ⅳ月|Ⅴ月|Ⅵ月|Ⅶ月|Ⅷ月|Ⅸ月|Ⅹ月|Ⅺ月|Ⅻ月",
+		})
+		s.Equal("Ⅷ月", Parse("2020-08-05").SetLanguage(lang1).ToMonthString())
+
+		// the cached resources must stay untouched for every other instance
+		lang2 := NewLanguage().SetLocale("en")
+		s.Equal("August", Parse("2020-08-05").SetLanguage(lang2).ToMonthString())
+	})
+
 	s.Run("set all resources", func() {
 		resources := map[string]string{
 			"constellations": "Aries|Taurus|Gemini|Cancer|Leo|Virgo|Libra|Scorpio|Sagittarius|Capricorn|Aquarius|Pisces",


### PR DESCRIPTION
Closes #349.

## Problem

`SetLocale` copies the whole cached locale map into every `Language` instance
(language.go:109-114). `NewCarbon()` calls `NewLanguage().SetLocale(DefaultLocale)`,
so every Carbon instance produced by `Now()`, `Parse()` or any `CreateFromXxx()`
allocates and fills a fresh 20-entry map before it is used for anything.

In an allocation profile of 500k `NewCarbon()` calls on master, one line
dominates:

```
  596.62MB   596.62MB    111:	newResources := make(map[string]string, len(entry.resources))
```

That is 76% of everything `NewCarbon()` allocates.

## Why the copy cannot simply be removed

The copy was added in 63a26af to keep `SetResources` from modifying the shared
cache, and that concern is real. Sharing the cached map with no further change
lets one instance poison the cache for the whole process:

```go
b := NewLanguage().SetLocale("en")
b.SetResources(map[string]string{"months": "CORRUPTED"})
c := NewLanguage().SetLocale("en")   // brand new instance
// c.resources["months"] == "CORRUPTED"
```

## Change

Copy on write. `SetLocale` shares the cached map and marks it as shared;
`SetResources` copies before its first write and clears the flag. Everything
that only reads resources (`translate`, `Format`, `Season`, `Constellation`, ...)
keeps reading the shared map and never copies.

Alongside that, `Copy()` propagates the shared state instead of copying an
immutable map, `NewLanguage()` no longer allocates an empty map that `SetLocale`
immediately replaces, and `SetLocale` builds the cache key by concatenation
rather than `fmt.Sprintf` and only reaches for `LoadOrStore` on a miss, so
`new(cachedResources)` is no longer allocated on every hit.

## Benchmarks

```
go test -run '^$' -bench 'BenchmarkLB_' -benchtime=200000x -count=10
benchstat before.txt after.txt
```

go1.24.1, darwin/arm64, Apple M3:

| benchmark | before | after | |
| --- | --- | --- | --- |
| `NewCarbon` | 675.9n ± 4% | 108.0n ± 20% | -84.01% |
| `Now` | 719.0n ± 3% | 133.5n ± 1% | -81.44% |
| `Now` parallel | 395.60n ± 2% | 55.56n ± 3% | -85.96% |
| `Parse` | 754.0n ± 0% | 203.8n ± 1% | -72.96% |
| `CreateFromStdTime` | 640.45n ± 0% | 99.37n ± 2% | -84.49% |
| `SetLocale` | 600.85n ± 0% | 58.41n ± 1% | -90.28% |

Per `NewCarbon()`, allocation drops from 1600 B / 13 allocs to 232 B / 4 allocs.
`DiffForHumans`, which does not touch this path, moved by +0.6%; it is the only
other benchmark that moved at all.

## Tests

Added an `issue349` sub-test to `TestLanguage_SetResources` that guards the
invariant the copy was protecting: after one instance customises its resources,
a newly created instance still sees the pristine locale. Removing the
copy-on-write branch makes it fail with `expected: "August", actual: "Ⅷ月"`.

## Verification

```
go test ./...                                               all packages ok
go test -race ./...                                         all packages ok
go vet .                                                    clean
go test -coverprofile=coverage.txt -covermode=atomic ./...  100.0% of statements
TZ=UTC / America/New_York / Asia/Shanghai                   all packages ok
```

No public API changed and no existing test was modified. `Language` gains one
unexported bool field.

## Not included

As noted in #349, the `SetLanguage` aliasing at setter.go:168 is only partly
narrowed by this change, and closing it fully needs `SetLanguage` to mark both
owners as shared. I left that out to keep this change self-contained, and I am
happy to follow up on it separately.
