### PR TITLE
perf(i18n): Look up language resources without splitting them on every call

### DIFF
--- a/constellation.go
+++ b/constellation.go
@@ -1,9 +1,5 @@
 package carbon
 
-import (
-	"strings"
-)
-
 var constellations = []struct {
 	startMonth, startDay int
 	endMonth, endDay     int
@@ -48,13 +44,7 @@ func (c *Carbon) Constellation() string {
 	lang.rw.RLock()
 	defer lang.rw.RUnlock()
 
-	if resources, ok := lang.resources["constellations"]; ok {
-		slice := strings.Split(resources, "|")
-		if len(slice) == MonthsPerYear {
-			return slice[index]
-		}
-	}
-	return ""
+	return getResourceItem(lang.resources["constellations"], index, MonthsPerYear)
 }
 
 // IsAries reports whether is Aries.

--- a/helper.go
+++ b/helper.go
@@ -2,6 +2,7 @@ package carbon
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -191,4 +192,19 @@ func getAbsValue(value int64) int64 {
 	// For positive numbers: value ^ 0 - 0 = value
 	// For negative numbers: value ^ -1 - (-1) = ^value + 1 = -value
 	return (value ^ (value >> 63)) - (value >> 63)
+}
+
+// gets the item at index from a resource separated by "|", returns an empty string
+// unless the resource holds exactly count items.
+func getResourceItem(resource string, index, count int) string {
+	if index < 0 || index >= count || strings.Count(resource, "|") != count-1 {
+		return ""
+	}
+	for i := 0; i < index; i++ {
+		resource = resource[strings.IndexByte(resource, '|')+1:]
+	}
+	if i := strings.IndexByte(resource, '|'); i >= 0 {
+		return resource[:i]
+	}
+	return resource
 }

--- a/helper_bench_test.go
+++ b/helper_bench_test.go
@@ -178,3 +178,23 @@ func BenchmarkGetAbsValue(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkGetResourceItem benchmarks the getResourceItem function
+func BenchmarkGetResourceItem(b *testing.B) {
+	monthsResource := "January|February|March|April|May|June|July|August|September|October|November|December"
+	weeksResource := "Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday"
+	seasonsResource := "Spring|Summer|Autumn|Winter"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for index := 0; index < MonthsPerYear; index++ {
+			_ = getResourceItem(monthsResource, index, MonthsPerYear)
+		}
+		for index := 0; index < DaysPerWeek; index++ {
+			_ = getResourceItem(weeksResource, index, DaysPerWeek)
+		}
+		for index := 0; index < QuartersPerYear; index++ {
+			_ = getResourceItem(seasonsResource, index, QuartersPerYear)
+		}
+	}
+}

--- a/helper_unit_test.go
+++ b/helper_unit_test.go
@@ -454,3 +454,122 @@ func TestGetAbsValue(t *testing.T) {
 		})
 	}
 }
+
+// Test getResourceItem function
+func TestGetResourceItem(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		index    int
+		count    int
+		expected string
+	}{
+		{
+			name:     "First item",
+			resource: "a|b|c",
+			index:    0,
+			count:    3,
+			expected: "a",
+		},
+		{
+			name:     "Middle item",
+			resource: "a|b|c",
+			index:    1,
+			count:    3,
+			expected: "b",
+		},
+		{
+			name:     "Last item",
+			resource: "a|b|c",
+			index:    2,
+			count:    3,
+			expected: "c",
+		},
+		{
+			name:     "Single item",
+			resource: "a",
+			index:    0,
+			count:    1,
+			expected: "a",
+		},
+		{
+			name:     "Empty item",
+			resource: "a||c",
+			index:    1,
+			count:    3,
+			expected: "",
+		},
+		{
+			name:     "Empty resource",
+			resource: "",
+			index:    0,
+			count:    3,
+			expected: "",
+		},
+		{
+			name:     "Too few items",
+			resource: "a|b",
+			index:    0,
+			count:    3,
+			expected: "",
+		},
+		{
+			name:     "Too many items",
+			resource: "a|b|c|d",
+			index:    0,
+			count:    3,
+			expected: "",
+		},
+		{
+			name:     "Negative index",
+			resource: "a|b|c",
+			index:    -1,
+			count:    3,
+			expected: "",
+		},
+		{
+			name:     "Index out of range",
+			resource: "a|b|c",
+			index:    3,
+			count:    3,
+			expected: "",
+		},
+		{
+			name:     "Multi-byte items",
+			resource: "Ⅰ月|Ⅱ月|Ⅲ月",
+			index:    2,
+			count:    3,
+			expected: "Ⅲ月",
+		},
+		{
+			name:     "Month resource",
+			resource: "January|February|March|April|May|June|July|August|September|October|November|December",
+			index:    7,
+			count:    MonthsPerYear,
+			expected: "August",
+		},
+		{
+			name:     "Week resource",
+			resource: "Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday",
+			index:    6,
+			count:    DaysPerWeek,
+			expected: "Saturday",
+		},
+		{
+			name:     "Season resource",
+			resource: "Spring|Summer|Autumn|Winter",
+			index:    3,
+			count:    QuartersPerYear,
+			expected: "Winter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getResourceItem(tt.resource, tt.index, tt.count)
+			if result != tt.expected {
+				t.Errorf("getResourceItem(%q, %d, %d) = %q, want %q", tt.resource, tt.index, tt.count, result, tt.expected)
+			}
+		})
+	}
+}

--- a/outputer.go
+++ b/outputer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 // GoString implements "fmt.GoStringer" interface for Carbon struct.
@@ -43,13 +42,7 @@ func (c *Carbon) ToMonthString(timezone ...string) string {
 	lang.rw.RLock()
 	defer lang.rw.RUnlock()
 
-	if resources, ok := lang.resources["months"]; ok {
-		slice := strings.Split(resources, "|")
-		if len(slice) == MonthsPerYear {
-			return slice[c.Month()-1]
-		}
-	}
-	return ""
+	return getResourceItem(lang.resources["months"], c.Month()-1, MonthsPerYear)
 }
 
 // ToShortMonthString outputs a string in short month layout like "Jan", i18n is supported.
@@ -69,13 +62,7 @@ func (c *Carbon) ToShortMonthString(timezone ...string) string {
 	lang.rw.RLock()
 	defer lang.rw.RUnlock()
 
-	if resources, ok := lang.resources["short_months"]; ok {
-		slice := strings.Split(resources, "|")
-		if len(slice) == MonthsPerYear {
-			return slice[c.Month()-1]
-		}
-	}
-	return ""
+	return getResourceItem(lang.resources["short_months"], c.Month()-1, MonthsPerYear)
 }
 
 // ToWeekString outputs a string in week layout like "Sunday", i18n is supported.
@@ -95,13 +82,7 @@ func (c *Carbon) ToWeekString(timezone ...string) string {
 	lang.rw.RLock()
 	defer lang.rw.RUnlock()
 
-	if resources, ok := lang.resources["weeks"]; ok {
-		slice := strings.Split(resources, "|")
-		if len(slice) == DaysPerWeek {
-			return slice[c.DayOfWeek()%DaysPerWeek]
-		}
-	}
-	return ""
+	return getResourceItem(lang.resources["weeks"], c.DayOfWeek()%DaysPerWeek, DaysPerWeek)
 }
 
 // ToShortWeekString outputs a string in short week layout like "Sun", i18n is supported.
@@ -121,13 +102,7 @@ func (c *Carbon) ToShortWeekString(timezone ...string) string {
 	lang.rw.RLock()
 	defer lang.rw.RUnlock()
 
-	if resources, ok := lang.resources["short_weeks"]; ok {
-		slice := strings.Split(resources, "|")
-		if len(slice) == DaysPerWeek {
-			return slice[c.DayOfWeek()%DaysPerWeek]
-		}
-	}
-	return ""
+	return getResourceItem(lang.resources["short_weeks"], c.DayOfWeek()%DaysPerWeek, DaysPerWeek)
 }
 
 // ToDayDateTimeString outputs a string in "Mon, Jan 2, 2006 3:04 PM" layout.

--- a/season.go
+++ b/season.go
@@ -1,9 +1,5 @@
 package carbon
 
-import (
-	"strings"
-)
-
 var seasons = map[int]int{
 	// month: index
 	1:  3, // winter
@@ -34,13 +30,7 @@ func (c *Carbon) Season() string {
 	lang.rw.RLock()
 	defer lang.rw.RUnlock()
 
-	if resources, ok := lang.resources["seasons"]; ok {
-		slice := strings.Split(resources, "|")
-		if len(slice) == QuartersPerYear {
-			return slice[seasons[c.Month()]]
-		}
-	}
-	return ""
+	return getResourceItem(lang.resources["seasons"], seasons[c.Month()], QuartersPerYear)
 }
 
 // StartOfSeason returns a Carbon instance for start of the season.


### PR DESCRIPTION
Closes #351.

## Problem

Six methods read a "|" separated language resource, split it, and return a
single item:

```go
if resources, ok := lang.resources["months"]; ok {
	slice := strings.Split(resources, "|")
	if len(slice) == MonthsPerYear {
		return slice[c.Month()-1]
	}
}
return ""
```

`strings.Split` allocates a slice of 4 to 12 strings on every call just to index
one element, so `ToMonthString`, `ToShortMonthString`, `ToWeekString`,
`ToShortWeekString`, `Season` and `Constellation` each allocate every time they
are called.

## Change

A small unexported helper in helper.go locates the item in place: `strings.Count`
gives the item count and `strings.IndexByte` walks to the wanted index. The
result is a substring of the resource, so nothing is allocated.

```go
func getResourceItem(resource string, index, count int) string {
	if index < 0 || index >= count || strings.Count(resource, "|") != count-1 {
		return ""
	}
	for i := 0; i < index; i++ {
		resource = resource[strings.IndexByte(resource, '|')+1:]
	}
	if i := strings.IndexByte(resource, '|'); i >= 0 {
		return resource[:i]
	}
	return resource
}
```

Each of the six call sites becomes one line, for example:

```go
return getResourceItem(lang.resources["months"], c.Month()-1, MonthsPerYear)
```

The helper also covers the guards the old code had: a missing key yields an
empty resource, and a resource that does not hold exactly the expected number of
items yields an empty string, exactly as before.

## Benchmarks

Each method benchmarked on a fixed instance, `Parse("2020-08-05 13:14:15")`:

```
go test -run '^$' -bench 'BenchmarkI18N_' -benchtime=300000x -count=8
benchstat before.txt after.txt
```

go1.24.1, darwin/arm64, Apple M3:

| benchmark | before | after | |
| --- | --- | --- | --- |
| `Constellation` | 165.10n ± 1% | 63.51n ± 1% | -61.54% |
| `ToShortWeekString` | 99.75n ± 1% | 52.52n ± 1% | -47.35% |
| `ToWeekString` | 92.66n ± 1% | 51.77n ± 1% | -44.13% |
| `Season` | 67.07n ± 1% | 39.80n ± 1% | -40.65% |
| `ToMonthString` | 152.90n ± 1% | 95.33n ± 9% | -37.66% |
| `ToShortMonthString` | 151.05n ± 1% | 96.86n ± 1% | -35.88% |

All six go from 1 alloc per call (192 B, 112 B or 64 B) to zero allocations.

`DiffForHumans` is unchanged; it goes through `Language.translate`, which this
patch does not touch.

## Tests

Added `TestGetResourceItem` to helper_unit_test.go and `BenchmarkGetResourceItem`
to helper_bench_test.go, following the table driven style already used for
`format2layout`, `parseTimezone`, `parseDuration` and `getAbsValue`.

Beyond that I compared the old and the new implementation directly, over every
shipped locale times every day of a leap year, plus malformed, empty and random
resource strings: 85,590 cases times 6 methods, no differences. That check is
not part of the patch.

## Verification

```
go test ./...                                               all packages ok
go test -race ./...                                         all packages ok
go vet .                                                    clean
go test -coverprofile=coverage.txt -covermode=atomic ./...  100.0% of statements
TZ=UTC / America/New_York / Asia/Shanghai                   all packages ok
```

No public API changed. No existing test was changed either: the two test files
only gained the new functions above. The `strings` import is no longer needed in
outputer.go, season.go and constellation.go.

## Not included

`Language.translate` splits on every call as well, but it indexes
`slice[number-1]`, which panics when `number` is 0. That is only reachable when
the "now" resource is given a "|", which no shipped locale has. It looks like a
separate question rather than something to change inside a performance patch, so
I left it alone and can follow up separately.
