### PR TITLE
perf(language): Share one language instance per locale

### DIFF
--- a/carbon.go
+++ b/carbon.go
@@ -32,7 +32,7 @@ type Carbon struct {
 // NewCarbon returns a new Carbon instance.
 func NewCarbon(stdTime ...StdTime) *Carbon {
 	c := new(Carbon)
-	c.lang = NewLanguage().SetLocale(DefaultLocale)
+	c.lang = defaultLanguage(DefaultLocale)
 	c.weekStartsAt = DefaultWeekStartsAt
 	c.weekendDays = DefaultWeekendDays
 	c.currentLayout = DefaultLayout
@@ -51,14 +51,10 @@ func (c *Carbon) Copy() *Carbon {
 		return nil
 	}
 
-	// Create a deep copy of weekendDays slice to avoid shared reference
-	weekendDays := make([]Weekday, len(c.weekendDays))
-	copy(weekendDays, c.weekendDays)
-
 	return &Carbon{
 		time:          c.time,
 		weekStartsAt:  c.weekStartsAt,
-		weekendDays:   weekendDays,
+		weekendDays:   c.weekendDays,
 		loc:           c.loc,
 		lang:          c.lang,
 		currentLayout: c.currentLayout,

--- a/carbon_unit_test.go
+++ b/carbon_unit_test.go
@@ -130,6 +130,22 @@ func (s *CarbonSuite) TestCarbon_Copy() {
 		s.Equal("8月", newCarbon.ToMonthString())
 	})
 
+	// https://github.com/dromara/carbon/issues/353
+	s.Run("copy lang customization", func() {
+		oldCarbon := Parse("2020-08-05")
+		newCarbon := oldCarbon.Copy()
+
+		lang := NewLanguage()
+		lang.SetLocale("en")
+		lang.SetResources(map[string]string{
+			"months": "Ⅰ|Ⅱ|Ⅲ|Ⅳ|Ⅴ|Ⅵ|Ⅶ|Ⅷ|Ⅸ|Ⅹ|Ⅺ|Ⅻ",
+		})
+		newCarbon = newCarbon.SetLanguage(lang)
+
+		s.Equal("Ⅷ", newCarbon.ToMonthString())
+		s.Equal("August", oldCarbon.ToMonthString())
+	})
+
 	s.Run("copy error", func() {
 		oldCarbon := Parse("xxx")
 		newCarbon := oldCarbon.Copy()

--- a/creator.go
+++ b/creator.go
@@ -150,7 +150,7 @@ func (c *Carbon) create(year, month, day, hour, minute, second, nanosecond int) 
 		weekStartsAt:  c.weekStartsAt,
 		weekendDays:   c.weekendDays,
 		loc:           c.loc,
-		lang:          c.lang.Copy(),
+		lang:          c.lang,
 		currentLayout: c.currentLayout,
 		isEmpty:       c.isEmpty,
 		Error:         c.Error,

--- a/language.go
+++ b/language.go
@@ -22,6 +22,23 @@ type cachedResources struct {
 	err       error
 }
 
+// defaultLanguages caches one ready-to-use Language per locale. The cached
+// resources are never written to, so every Carbon can share the same instance.
+var defaultLanguages sync.Map
+
+// returns a shared Language for the given locale.
+func defaultLanguage(locale string) *Language {
+	if cached, exists := defaultLanguages.Load(locale); exists {
+		return cached.(*Language)
+	}
+	lang := NewLanguage().SetLocale(locale)
+	if lang.Error != nil {
+		return lang
+	}
+	actual, _ := defaultLanguages.LoadOrStore(locale, lang)
+	return actual.(*Language)
+}
+
 // Language defines a Language struct.
 type Language struct {
 	dir       string

--- a/language_unit_test.go
+++ b/language_unit_test.go
@@ -2,6 +2,7 @@ package carbon
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -45,6 +46,21 @@ func (s *LanguageSuite) TestLanguage_Copy() {
 		oldLang.locale = "en"
 		newCarbon := oldLang.Copy()
 		s.Equal(oldLang.locale, newCarbon.locale)
+	})
+
+	s.Run("copy shared resources", func() {
+		oldLang := NewLanguage()
+		oldLang.SetLocale("en")
+		newLang := oldLang.Copy()
+
+		s.True(newLang.shared)
+		s.Equal(oldLang.resources, newLang.resources)
+
+		newLang.SetResources(map[string]string{
+			"months": "Ⅰ|Ⅱ|Ⅲ|Ⅳ|Ⅴ|Ⅵ|Ⅶ|Ⅷ|Ⅸ|Ⅹ|Ⅺ|Ⅻ",
+		})
+		s.False(newLang.shared)
+		s.NotEqual(oldLang.resources, newLang.resources)
 	})
 
 	s.Run("copy resources", func() {
@@ -373,5 +389,64 @@ func (s *LanguageSuite) TestLanguage_translate() {
 		lang.resources = make(map[string]string, 0) // Start with empty
 		result := lang.translate("month", 1)
 		s.NotEmpty(result) // Should have loaded default locale successfully
+	})
+}
+
+// https://github.com/dromara/carbon/issues/353
+func (s *LanguageSuite) TestDefaultLanguage() {
+	s.Run("same instance per locale", func() {
+		s.Same(defaultLanguage("en"), defaultLanguage("en"))
+		s.NotSame(defaultLanguage("en"), defaultLanguage("zh-CN"))
+	})
+
+	s.Run("invalid locale", func() {
+		lang := defaultLanguage("xxx")
+		s.Error(lang.Error)
+		s.NotSame(lang, defaultLanguage("xxx"))
+	})
+
+	s.Run("shared by carbon instances", func() {
+		s.Same(Now().lang, Now().lang)
+	})
+
+	s.Run("customized language does not affect other instances", func() {
+		lang := NewLanguage().SetLocale("en")
+		lang.SetResources(map[string]string{
+			"months": "Ⅰ|Ⅱ|Ⅲ|Ⅳ|Ⅴ|Ⅵ|Ⅶ|Ⅷ|Ⅸ|Ⅹ|Ⅺ|Ⅻ",
+		})
+
+		s.Equal("Ⅷ", Parse("2020-08-05").SetLanguage(lang).ToMonthString())
+		s.Equal("August", Parse("2020-08-05").ToMonthString())
+	})
+
+	s.Run("default locale changed at runtime", func() {
+		defer ResetDefault()
+
+		SetDefault(Default{Locale: "zh-CN"})
+		s.Equal("八月", Parse("2020-08-05").ToMonthString())
+
+		ResetDefault()
+		s.Equal("August", Parse("2020-08-05").ToMonthString())
+	})
+
+	s.Run("concurrent use", func() {
+		var wg sync.WaitGroup
+		results := make([]string, 8)
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func(index int) {
+				defer wg.Done()
+				result := ""
+				for k := 0; k < 100; k++ {
+					result = Parse("2020-08-05").ToMonthString()
+				}
+				results[index] = result
+			}(i)
+		}
+		wg.Wait()
+
+		for _, result := range results {
+			s.Equal("August", result)
+		}
 	})
 }

--- a/setter.go
+++ b/setter.go
@@ -1,6 +1,9 @@
 package carbon
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // SetLayout sets globally default layout.
 func SetLayout(layout string) *Carbon {
@@ -127,7 +130,7 @@ func (c *Carbon) SetLocale(locale string) *Carbon {
 	if c.IsInvalid() {
 		return c
 	}
-	c.lang = NewLanguage().SetLocale(locale)
+	c.lang = defaultLanguage(locale)
 	c.Error = c.lang.Error
 	return c
 }
@@ -163,10 +166,18 @@ func (c *Carbon) SetLanguage(lang *Language) *Carbon {
 		c.Error = ErrInvalidLanguage(lang)
 		return c
 	}
-	c.lang.dir = lang.dir
-	c.lang.locale = lang.locale
-	c.lang.resources = lang.resources
-	c.lang.Error = lang.Error
+	lang.rw.RLock()
+	resources := lang.resources
+	lang.rw.RUnlock()
+
+	c.lang = &Language{
+		dir:       lang.dir,
+		locale:    lang.locale,
+		resources: resources,
+		shared:    true,
+		Error:     lang.Error,
+		rw:        new(sync.RWMutex),
+	}
 	return c
 }
 

--- a/setter_unit_test.go
+++ b/setter_unit_test.go
@@ -828,6 +828,20 @@ func (s *SetterSuite) TestCarbon_SetLanguage() {
 		s.True(c.HasError())
 		s.Empty(c.ToString())
 	})
+
+	// https://github.com/dromara/carbon/issues/353
+	s.Run("customizing the source language afterwards", func() {
+		lang := NewLanguage()
+		lang.SetLocale("en")
+		c := Parse("2020-08-05").SetLanguage(lang)
+		s.Equal("August", c.ToMonthString())
+
+		lang.SetResources(map[string]string{
+			"months": "Ⅰ|Ⅱ|Ⅲ|Ⅳ|Ⅴ|Ⅵ|Ⅶ|Ⅷ|Ⅸ|Ⅹ|Ⅺ|Ⅻ",
+		})
+		s.Equal("August", c.ToMonthString())
+		s.Equal("August", Parse("2020-08-05").ToMonthString())
+	})
 }
 
 func (s *SetterSuite) TestCarbon_SetDateTime() {


### PR DESCRIPTION
Closes #353.

## Problem

`NewCarbon()` builds a fresh `Language` for every instance:

```go
c.lang = NewLanguage().SetLocale(DefaultLocale)
```

That is a `Language` struct, a `sync.RWMutex` and the `"lang/en.json"` string per
Carbon, and `NewCarbon` sits behind `Now()`, `Parse()` and every
`CreateFromXxx()`. On top of that `create()` copied the language again for every
`StartOfXxx`/`EndOfXxx`, and `Copy()` duplicated the `weekendDays` slice. Three
of the four allocations per Carbon were this per-instance language machinery.

None of it differs between instances:

- since #350 the locale resources are shared and copied on write, so the cached
  table is already immutable;
- nothing writes `weekendDays` in place, `SetWeekendDays` assigns a new slice;
- the mutex guards data that is never written.

## Change

- `defaultLanguage(locale)` caches one ready-to-use `Language` per locale in a
  `sync.Map` and `NewCarbon` takes it from there. Keyed by locale because
  `DefaultLocale` can be changed at runtime through `SetDefault`. A locale that
  fails to load is returned but not cached.
- `create()` shares the language instead of copying it.
- `Copy()` no longer duplicates `weekendDays`.
- `SetLocale` on a Carbon takes the cached instance too.
- `SetLanguage` replaces `c.lang` with a new instance instead of writing into
  the existing one. This is what makes the sharing safe: the shared instance
  must never be written through.

## Benchmarks

```
go test -run '^$' -bench 'BenchmarkSL_' -benchtime=200000x -count=8
benchstat before.txt after.txt
```

go1.24.1, darwin/arm64, Apple M3, against 41b3662:

| benchmark | before | after | |
| --- | --- | --- | --- |
| `Copy` | 8.6245n ± 2%, 16 B, 1 alloc | 0.2639n ± 3%, 0 B, 0 allocs | -96.94% |
| `SetLocale` | 77.06n ± 1%, 120 B, 3 allocs | 10.76n ± 2%, 0 B, 0 allocs | -86.04% |
| `CreateFromStdTime` | 95.78n ± 3%, 232 B, 4 allocs | 28.56n ± 2%, 112 B, 1 alloc | -70.18% |
| `Now` parallel | 57.31n ± 5%, 232 B, 4 allocs | 26.30n ± 10%, 112 B, 1 alloc | -54.11% |
| `StartOfDay` | 68.00n ± 4%, 216 B, 3 allocs | 33.28n ± 3%, 112 B, 1 alloc | -51.06% |
| `Now` | 130.00n ± 13%, 232 B, 4 allocs | 67.41n ± 29%, 112 B, 1 alloc | -48.15% |
| `Parse` | 197.1n ± 2%, 232 B, 4 allocs | 128.5n ± 2%, 112 B, 1 alloc | -34.80% |
| `Now().AddDays(1).StartOfDay().ToDateTimeString()` | 348.0n ± 2%, 600 B, 10 allocs | 228.2n ± 1%, 360 B, 4 allocs | -34.43% |
| `AddDays` | 46.37n ± 1%, 128 B, 2 allocs | 36.45n ± 4%, 112 B, 1 alloc | -21.39% |

Constructing a Carbon goes from 4 allocations to 1, and a three step chain from
10 to 4.

## The cost, stated up front

`SetLanguage` gets slower: 2.744n ± 4% and no allocation becomes 29.355n ± 3%
and 2 allocations, because it now builds the replacement instance instead of
writing four fields into an existing one. It runs once per customised Carbon
while the methods above run on every instance, so I think the trade is worth it,
but it is a real regression.

## Behaviour change

`Copy()` already shared the language pointer, so on master a language set on a
copy reaches the carbon it was copied from:

```go
oldCarbon := Parse("2020-08-05")
newCarbon := oldCarbon.Copy()

lang := NewLanguage()
lang.SetLocale("en")
lang.SetResources(map[string]string{"months": "Ⅰ|Ⅱ|Ⅲ|Ⅳ|Ⅴ|Ⅵ|Ⅶ|Ⅷ|Ⅸ|Ⅹ|Ⅺ|Ⅻ"})
newCarbon.SetLanguage(lang)

newCarbon.ToMonthString() // "Ⅷ"
oldCarbon.ToMonthString() // "Ⅷ" on master, "August" after this change
```

Making `SetLanguage` replace the instance fixes this as a side effect. It is
covered by the `copy lang customization` sub-test, which fails on master.

## Tests

New sub-tests, all following the existing suite style:

- `TestDefaultLanguage`: same instance per locale, invalid locale not cached,
  carbon instances share it, a customised language does not affect other
  instances, `DefaultLocale` changed at runtime, concurrent use.
- `TestLanguage_Copy/copy shared resources`: copying a shared language keeps it
  shared, and writing to the copy does not touch the source.
- `TestCarbon_Copy/copy lang customization`: the behaviour change above.
- `TestCarbon_SetLanguage/customizing the source language afterwards`: the
  carbon keeps the language it was given.

## Verification

```
go test ./...                                               all packages ok
go test -race ./...                                         all packages ok
go vet .                                                    clean
go test -coverprofile=coverage.txt -covermode=atomic ./...  100.0% of statements
TZ=UTC / America/New_York / Asia/Shanghai                   all packages ok
```

No public API changed. `Language.Copy()` keeps its signature and behaviour; it
simply is no longer called from `create()`.
