### PR TITLE
perf(lunar): Derive the day tables once instead of recounting them per call

### DIFF
--- a/calendar/lunar/lunar.go
+++ b/calendar/lunar/lunar.go
@@ -454,11 +454,7 @@ func getOffsetInYear(year, month int) int {
 // This represents the cumulative days across all years up to but not including the target year.
 // Returns the offset in days.
 func getOffsetInMonth(year int) int {
-	offset := 0
-	for y := minYear; y < year; y++ {
-		offset += getDaysInYear(y)
-	}
-	return offset
+	return daysBeforeYearTable[year-minYear]
 }
 
 // getDaysInYear calculates the total number of days in a lunar year.
@@ -467,6 +463,29 @@ func getOffsetInMonth(year int) int {
 // Finally adds the leap month days if the year has a leap month.
 // Returns the total number of days in the year.
 func getDaysInYear(year int) int {
+	return daysInYearTable[year-minYear]
+}
+
+// daysInYearTable holds the number of days in every supported lunar year, and
+// daysBeforeYearTable the running total of those days since minYear. Both are
+// derived from the years table once, so that walking towards a year costs a
+// lookup instead of recounting the month bits of every year in between.
+var daysInYearTable, daysBeforeYearTable = func() ([]int, []int) {
+	daysInYear := make([]int, len(years))
+	daysBeforeYear := make([]int, len(years))
+	total := 0
+	for i := range daysInYear {
+		daysBeforeYear[i] = total
+		daysInYear[i] = countDaysInYear(minYear + i)
+		total += daysInYear[i]
+	}
+	return daysInYear, daysBeforeYear
+}()
+
+// countDaysInYear counts the days of a lunar year from the lunar calendar data.
+// The base is 348 days (12 months x 29 days), then adds days for months with
+// 30 days, and finally adds the leap month days if the year has a leap month.
+func countDaysInYear(year int) int {
 	var days = 348
 	for i := 0x8000; i > 0x8; i >>= 1 {
 		if (years[year-minYear] & i) != 0 {

--- a/calendar/lunar/lunar_unit_test.go
+++ b/calendar/lunar/lunar_unit_test.go
@@ -533,3 +533,24 @@ func TestLunar_AuthorityData(t *testing.T) {
 		}
 	}
 }
+
+func TestDayTables(t *testing.T) {
+	t.Run("days in year matches the lunar calendar data", func(t *testing.T) {
+		for year := minYear; year <= maxYear; year++ {
+			assert.Equal(t, countDaysInYear(year), getDaysInYear(year), "year %d", year)
+		}
+	})
+
+	t.Run("days before year is the running total", func(t *testing.T) {
+		total := 0
+		for year := minYear; year <= maxYear; year++ {
+			assert.Equal(t, total, getOffsetInMonth(year), "year %d", year)
+			total += countDaysInYear(year)
+		}
+	})
+
+	t.Run("tables cover the whole lunar calendar data", func(t *testing.T) {
+		assert.Len(t, daysInYearTable, len(years))
+		assert.Len(t, daysBeforeYearTable, len(years))
+	})
+}


### PR DESCRIPTION
Closes #356.

## Problem

Both lunar conversions walk the year table instead of indexing it.

`FromStdTime` steps from `minYear` towards the wanted year and calls
`getDaysInYear` on every step, and `getDaysInYear` recounts the month bits of
that year each time:

```go
func getDaysInYear(year int) int {
	var days = 348
	for i := 0x8000; i > 0x8; i >>= 1 {
		if (years[year-minYear] & i) != 0 {
			days++
		}
	}
	return days + getDaysInLeapMonth(year)
}
```

`ToGregorian` does the same through `getOffsetInMonth`, which sums the length of
every year since `minYear`:

```go
func getOffsetInMonth(year int) int {
	offset := 0
	for y := minYear; y < year; y++ {
		offset += getDaysInYear(y)
	}
	return offset
}
```

So both cost O(years since 1900), and a CPU profile of the conversion spends
26.6% of its time in `getDaysInYear`.

## Change

Everything those loops compute follows from the static `years` table, so it is
derived once: the number of days in each supported year, and the running total
of those days since `minYear`. Both tables are 201 ints, built at package
initialisation. The two accessors become lookups:

```go
func getDaysInYear(year int) int {
	return daysInYearTable[year-minYear]
}

func getOffsetInMonth(year int) int {
	return daysBeforeYearTable[year-minYear]
}
```

The bit counting itself moves to `countDaysInYear`, which now runs 201 times at
startup instead of once per conversion step. The year finding logic in
`FromStdTime` is untouched.

Both accessors are already gated by their callers: `FromStdTime` starts its loop
at `minYear` and stops at `maxYear`, and `ToGregorian` calls `getOffsetInMonth`
only after `IsValid`, which checks the year range. The previous code indexed
`years[year-minYear]` unguarded in the same way.

## Benchmarks

```
go test -run '^$' -bench '.' -benchtime=200000x ./calendar/lunar/
```

go1.24.1, darwin/arm64, Apple M3:

| date | to lunar | back to gregorian |
| --- | --- | --- |
| 1901-02-05 | 107 ns -> 97 ns | 31.0 ns -> 30.0 ns |
| 2020-08-05 | 1009 ns -> 282 ns (-72%) | 738 ns -> 23 ns (-97%) |
| 2099-08-05 | 1504 ns -> 362 ns (-76%) | 1221 ns -> 22 ns (-98%) |

Allocations are unchanged: one for the returned struct.

## Correctness

The accessors are memoized pure functions of the same table, so the output
cannot change, and I checked that instead of assuming it. For every one of the
73384 days of the supported range I hashed both directions, `String`,
`ToYearString`, `ToMonthString`, `ToDayString`, `IsLeapMonth`, `Animal`,
`Festival` and the result of `ToGregorian`. The digest is identical before and
after the change.

## Tests

`TestDayTables` pins both tables to the definitions they replace: one sub-test
compares `getDaysInYear` against `countDaysInYear` for every supported year, one
rebuilds the running total step by step and compares it against
`getOffsetInMonth`, and one checks that both tables cover the whole `years`
table.

I verified the test is worth its lines by breaking the table on purpose: moving
the running total one year out of step makes it fail on the first year with
`expected: 0, actual: 384`. The existing tests do notice that break too, but
they report it as eight date assertions failing across the package, which says
much less about what went wrong.

## Verification

```
go test ./...                                               all packages ok
go test -race ./...                                         all packages ok
go test -coverprofile=coverage.txt -covermode=atomic ./calendar/lunar/   100.0%
TZ=UTC / America/New_York / Asia/Shanghai                   all packages ok
```

No exported API changed.

## What is left

The forward conversion is still O(years), it just does a lookup per step now.
Searching the running totals would make it O(1) as well, but that changes the
year finding logic rather than only memoizing it, so I kept it out of this
change. The same pattern applies to `calendar/hebrew`, where `getJDNInYear` and
`getElapsedDays` account for 37% of a 1322 ns conversion, and `hebrew2jdn` is
recomputed inside the month loop. Happy to follow up on either.
